### PR TITLE
Add CIP cartrdige infos

### DIFF
--- a/data/pistol/cip.json
+++ b/data/pistol/cip.json
@@ -1,96 +1,1090 @@
 {
-    "5.45 x 18": {},
-    "5.75 Velodog": {},
-    "6.35 Browning": {},
-    "7 x 49 Guido J. Wasser": {},
-    "7 Penna": {},
-    "7mm Penna L": {},
-    "7.5 FK": {},
-    "7.5 Ordonnance Suisse": {},
-    "7.62 x 25 Tokarev": {},
-    "7.62 Nagant": {},
-    "7.63 Mauser": {},
-    "7.65 Browning": {},
-    "7.65 Long": {},
-    "7.65 Parabellum": {},
-    "8mm Gasser": {},
-    "8mm Lebel": {},
-    "8mm Steyr": {},
-    "9 x 18": {},
-    "9 x 20 VGW": {},
-    "9 x 21": {},
-    "9 x 22 Major": {},
-    "9 x 25 Super Automatic G": {},
-    "9mm Makarov": {},
-    "9mm Browning court": {},
-    "9mm Browning long": {},
-    "9mm Fast Accurate Reliable": {},
-    "9mm FX & CQT": {},
-    "9mm Luger": {},
-    "9mm Mauser": {},
-    "9mm Steyr": {},
-    "10 x 22 T": {},
-    "10mm Automatic": {},
-    "10mm Fast Accurate Reliable": {},
-    "10.4 Ordinanza Italiana": {},
-    "11mm 73": {},
-    "22 PICRA": {},
-    "22 Remington Jet Magnum": {},
-    "221 Remington Fireball": {},
-    "260 PICRA": {},
-    "30 PICRA": {},
-    "30-357 Armi e Tiro": {},
-    "32 Harrington & Richardson Magnum": {},
-    "32 Long Colt": {},
-    "32 Short Colt": {},
-    "32 Smith & Wesson": {},
-    "32 Smith & Wesson Long": {},
-    "32 Smith & Wesson Long Wad Cutter": {},
-    "320 Long": {},
-    "320 Short": {},
-    "357 Automatic Magnum": {},
-    "357 Magnum": {},
-    "357 Magnum (carb)": {},
-    "357 Maximum": {},
-    "357 SIG": {},
-    "38 Long Colt": {},
-    "38 Short Colt": {},
-    "38 Smith & Wesson. Colt New Police": {},
-    "38 Special": {},
-    "38 Special (carb)": {},
-    "38 Special Army Marksmanship Unit": {},
-    "38 Special Wad Cutter": {},
-    "38 Super Automatic": {},
-    "38/357 FX": {},
-    "38-45 Automatic Colt Pistol": {},
-    "380 Long": {},
-    "380 Short": {},
-    "40 Smith & Wesson": {},
-    "41 Action Express": {},
-    "41 Long Colt": {},
-    "41 Remington Magnum": {},
-    "44 Colt": {},
-    "44 Remington Magnum": {},
-    "44 Remington Magnum (carb)": {},
-    "44 Smith & Wesson Russian": {},
-    "44 Smith & Wesson Special": {},
-    "44 Smith & Wesson Special (carb)": {},
-    "45 Automatic": {},
-    "45 Automatic Rim": {},
-    "45 Colt": {},
-    "45 Colt (carb)": {},
-    "45 Glock Auto Pistol": {},
-    "45 HP": {},
-    "45 Smith & Wesson Schofield": {},
-    "45 Smith & Wesson Schofield (carb)": {},
-    "45 Winchester Magnum": {},
-    "450 SCH": {},
-    "450 Short": {},
-    "454 Casull": {},
-    "455 MK II": {},
-    "460 Smith & Wesson Magnum": {},
-    "475 Linebaugh": {},
-    "480 Ruger": {},
-    "50 Action Express": {},
-    "500 Smith & Wesson Magnum": {}
+  "10 x 22 T" : {
+    "name" : "10 x 22 T",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 22.7,
+      "coal_inch" : 0.8937012699999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page30.pdf" ],
+    "diameter_mm" : 10.0,
+    "diameter_inch" : 0.39370099999999997
+  },
+  "10.4 Ordinanza Italiana" : {
+    "name" : "10.4 Ordinanza Italiana",
+    "names" : [ "10.4 Ord. It." ],
+    "specs" : {
+      "coal_mm" : 30.2,
+      "coal_inch" : 1.1889770199999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page33.pdf" ],
+    "diameter_mm" : 11.1,
+    "diameter_inch" : 0.43700810999999995
+  },
+  "10mm Automatic" : {
+    "name" : "10mm Automatic",
+    "names" : [ "10 mm Auto" ],
+    "specs" : {
+      "coal_mm" : 32.0,
+      "coal_inch" : 1.2598432
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/10-mm-auto-en.pdf" ],
+    "diameter_mm" : 10.17,
+    "diameter_inch" : 0.400393917
+  },
+  "10mm Fast Accurate Reliable" : {
+    "name" : "10mm Fast Accurate Reliable",
+    "names" : [ "10 mm FAR" ],
+    "specs" : {
+      "coal_mm" : 32.2,
+      "coal_inch" : 1.26771722
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page32.pdf" ],
+    "diameter_mm" : 10.17,
+    "diameter_inch" : 0.400393917
+  },
+  "11mm 73" : {
+    "name" : "11mm 73",
+    "names" : [ "11 mm 73" ],
+    "specs" : {
+      "coal_mm" : 29.65,
+      "coal_inch" : 1.167323465
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/11-mm-73-en.pdf" ],
+    "diameter_mm" : 11.6,
+    "diameter_inch" : 0.45669316
+  },
+  "22 PICRA" : {
+    "name" : "22 PICRA",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 48.0,
+      "coal_inch" : 1.8897648
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page35.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "22 Remington Jet Magnum" : {
+    "name" : "22 Remington Jet Magnum",
+    "names" : [ "22 Rem.Jet Mag." ],
+    "specs" : {
+      "coal_mm" : 42.14,
+      "coal_inch" : 1.659056014
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page36.pdf" ],
+    "diameter_mm" : 5.65,
+    "diameter_inch" : 0.222441065
+  },
+  "221 Remington Fireball" : {
+    "name" : "221 Remington Fireball",
+    "names" : [ "221 Rem. Fireball" ],
+    "specs" : {
+      "coal_mm" : 46.48,
+      "coal_inch" : 1.8299222479999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page37.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "260 PICRA" : {
+    "name" : "260 PICRA",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 62.0,
+      "coal_inch" : 2.4409462
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page38.pdf" ],
+    "diameter_mm" : 6.71,
+    "diameter_inch" : 0.264173371
+  },
+  "30 PICRA" : {
+    "name" : "30 PICRA",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 56.0,
+      "coal_inch" : 2.2047255999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page39.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "30-357 Armi e Tiro" : {
+    "name" : "30-357 Armi e Tiro",
+    "names" : [ "30-357 AeT" ],
+    "specs" : {
+      "coal_mm" : 47.8,
+      "coal_inch" : 1.8818907799999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page40.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "32 Harrington & Richardson Magnum" : {
+    "name" : "32 Harrington & Richardson Magnum",
+    "names" : [ "32 H&R Mag." ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page41.pdf" ]
+  },
+  "32 Long Colt" : {
+    "name" : "32 Long Colt",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 30.89,
+      "coal_inch" : 1.216142389
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page42.pdf" ],
+    "diameter_mm" : 7.97,
+    "diameter_inch" : 0.31377969699999997
+  },
+  "32 Short Colt" : {
+    "name" : "32 Short Colt",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 25.78,
+      "coal_inch" : 1.014961178
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page43.pdf" ],
+    "diameter_mm" : 7.98,
+    "diameter_inch" : 0.314173398
+  },
+  "32 Smith & Wesson" : {
+    "name" : "32 Smith & Wesson",
+    "names" : [ "32 S&W" ],
+    "specs" : {
+      "coal_mm" : 23.62,
+      "coal_inch" : 0.929921762
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page44.pdf" ],
+    "diameter_mm" : 8.0,
+    "diameter_inch" : 0.3149608
+  },
+  "32 Smith & Wesson Long" : {
+    "name" : "32 Smith & Wesson Long",
+    "names" : [ "32 Colt New Police", "32 S&W Long" ],
+    "specs" : {
+      "coal_mm" : 32.51,
+      "coal_inch" : 1.279921951
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page45.pdf" ],
+    "diameter_mm" : 8.0,
+    "diameter_inch" : 0.3149608
+  },
+  "32 Smith & Wesson Long Wad Cutter" : {
+    "name" : "32 Smith & Wesson Long Wad Cutter",
+    "names" : [ "32 S&W Long Wad Cut." ],
+    "specs" : {
+      "coal_mm" : 25.4,
+      "coal_inch" : 1.0000005399999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page46.pdf" ],
+    "diameter_mm" : 8.0,
+    "diameter_inch" : 0.3149608
+  },
+  "320 Long" : {
+    "name" : "320 Long",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 30.0,
+      "coal_inch" : 1.181103
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page47.pdf" ],
+    "diameter_mm" : 7.7,
+    "diameter_inch" : 0.30314977
+  },
+  "320 Short" : {
+    "name" : "320 Short",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 26.7,
+      "coal_inch" : 1.0511816699999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page48.pdf" ],
+    "diameter_mm" : 8.0,
+    "diameter_inch" : 0.3149608
+  },
+  "357 Automatic Magnum" : {
+    "name" : "357 Automatic Magnum",
+    "names" : [ "357 Auto Mag." ],
+    "specs" : {
+      "coal_mm" : 40.65,
+      "coal_inch" : 1.6003945649999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page49.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "357 Magnum" : {
+    "name" : "357 Magnum",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 40.39,
+      "coal_inch" : 1.590158339
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/357-magnum-en.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "357 Magnum (carb)" : {
+    "name" : "357 Magnum (carb)",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/357-magnum-carb-en.pdf" ],
+    "diameter_mm" : 9.65,
+    "diameter_inch" : 0.379921465
+  },
+  "357 Maximum" : {
+    "name" : "357 Maximum",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 50.55,
+      "coal_inch" : 1.9901585549999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page52.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "357 SIG" : {
+    "name" : "357 SIG",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 28.96,
+      "coal_inch" : 1.140158096
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page53.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  },
+  "38 Long Colt" : {
+    "name" : "38 Long Colt",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 34.54,
+      "coal_inch" : 1.3598432539999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page54.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "38 Short Colt" : {
+    "name" : "38 Short Colt",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 30.48,
+      "coal_inch" : 1.200000648
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page55.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "38 Smith & Wesson. Colt New Police" : {
+    "name" : "38 Smith & Wesson. Colt New Police",
+    "names" : [ "38 S&W. Colt N.P." ],
+    "specs" : {
+      "coal_mm" : 31.5,
+      "coal_inch" : 1.2401581499999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page56.pdf" ],
+    "diameter_mm" : 9.17,
+    "diameter_inch" : 0.36102381699999997
+  },
+  "38 Special" : {
+    "name" : "38 Special",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 39.37,
+      "coal_inch" : 1.5500008369999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page57.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "38 Special (carb)" : {
+    "name" : "38 Special (carb)",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page58.pdf" ],
+    "diameter_mm" : 9.65,
+    "diameter_inch" : 0.379921465
+  },
+  "38 Special Army Marksmanship Unit" : {
+    "name" : "38 Special Army Marksmanship Unit",
+    "names" : [ "38 Spl. AMU" ],
+    "specs" : {
+      "coal_mm" : 30.23,
+      "coal_inch" : 1.190158123
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page59.pdf" ],
+    "diameter_mm" : 9.11,
+    "diameter_inch" : 0.35866161099999994
+  },
+  "38 Special Wad Cutter" : {
+    "name" : "38 Special Wad Cutter",
+    "names" : [ "38 Spl. Wad Cut." ],
+    "specs" : {
+      "coal_mm" : 30.35,
+      "coal_inch" : 1.194882535
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page60.pdf" ],
+    "diameter_mm" : 9.14,
+    "diameter_inch" : 0.359842714
+  },
+  "38 Super Automatic" : {
+    "name" : "38 Super Automatic",
+    "names" : [ "38 Super Auto" ],
+    "specs" : {
+      "coal_mm" : 32.51,
+      "coal_inch" : 1.279921951
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page61.pdf" ],
+    "diameter_mm" : 9.04,
+    "diameter_inch" : 0.35590570399999993
+  },
+  "38-45 Automatic Colt Pistol" : {
+    "name" : "38-45 Automatic Colt Pistol",
+    "names" : [ "38-45 ACP" ],
+    "specs" : {
+      "coal_mm" : 31.7,
+      "coal_inch" : 1.2480321699999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page63.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "38/357 FX" : {
+    "name" : "38/357 FX",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 30.99,
+      "coal_inch" : 1.2200793989999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page62.pdf" ],
+    "diameter_mm" : 8.94,
+    "diameter_inch" : 0.35196869399999997
+  },
+  "380 Long" : {
+    "name" : "380 Long",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 35.0,
+      "coal_inch" : 1.3779534999999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page64.pdf" ],
+    "diameter_mm" : 9.15,
+    "diameter_inch" : 0.360236415
+  },
+  "380 Short" : {
+    "name" : "380 Short",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 28.0,
+      "coal_inch" : 1.1023627999999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page65.pdf" ],
+    "diameter_mm" : 9.15,
+    "diameter_inch" : 0.360236415
+  },
+  "40 Smith & Wesson" : {
+    "name" : "40 Smith & Wesson",
+    "names" : [ "40 S&W" ],
+    "specs" : {
+      "coal_mm" : 28.83,
+      "coal_inch" : 1.135039983
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page66.pdf" ],
+    "diameter_mm" : 10.17,
+    "diameter_inch" : 0.400393917
+  },
+  "41 Action Express" : {
+    "name" : "41 Action Express",
+    "names" : [ "41 ACT EXP" ],
+    "specs" : {
+      "coal_mm" : 29.25,
+      "coal_inch" : 1.1515754249999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page67.pdf" ],
+    "diameter_mm" : 10.41,
+    "diameter_inch" : 0.409842741
+  },
+  "41 Long Colt" : {
+    "name" : "41 Long Colt",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 36.19,
+      "coal_inch" : 1.424803919
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page68.pdf" ],
+    "diameter_mm" : 9.86,
+    "diameter_inch" : 0.38818918599999996
+  },
+  "41 Remington Magnum" : {
+    "name" : "41 Remington Magnum",
+    "names" : [ "41 Rem. Mag." ],
+    "specs" : {
+      "coal_mm" : 40.39,
+      "coal_inch" : 1.590158339
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page69.pdf" ],
+    "diameter_mm" : 10.41,
+    "diameter_inch" : 0.409842741
+  },
+  "44 Colt" : {
+    "name" : "44 Colt",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 38.1,
+      "coal_inch" : 1.50000081
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page70.pdf" ],
+    "diameter_mm" : 11.25,
+    "diameter_inch" : 0.442913625
+  },
+  "44 Remington Magnum" : {
+    "name" : "44 Remington Magnum",
+    "names" : [ "44 Rem. Mag." ],
+    "specs" : {
+      "coal_mm" : 40.89,
+      "coal_inch" : 1.609843389
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page71.pdf" ],
+    "diameter_mm" : 10.97,
+    "diameter_inch" : 0.431889997
+  },
+  "44 Remington Magnum (carb)" : {
+    "name" : "44 Remington Magnum (carb)",
+    "names" : [ "44 Rem. Mag. (carb)" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page72.pdf" ],
+    "diameter_mm" : 11.63,
+    "diameter_inch" : 0.457874263
+  },
+  "44 Smith & Wesson Russian" : {
+    "name" : "44 Smith & Wesson Russian",
+    "names" : [ "44 S&W Russian" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page73.pdf" ]
+  },
+  "44 Smith & Wesson Special" : {
+    "name" : "44 Smith & Wesson Special",
+    "names" : [ "44 S&W Special" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page74.pdf" ]
+  },
+  "44 Smith & Wesson Special (carb)" : {
+    "name" : "44 Smith & Wesson Special (carb)",
+    "names" : [ "44 S&W Special (carb)" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page75.pdf" ]
+  },
+  "45 Automatic" : {
+    "name" : "45 Automatic",
+    "names" : [ "45 Auto" ],
+    "specs" : {
+      "coal_mm" : 32.39,
+      "coal_inch" : 1.2751975389999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page76.pdf" ],
+    "diameter_mm" : 11.48,
+    "diameter_inch" : 0.451968748
+  },
+  "45 Automatic Rim" : {
+    "name" : "45 Automatic Rim",
+    "names" : [ "45 Auto Rim" ],
+    "specs" : {
+      "coal_mm" : 32.39,
+      "coal_inch" : 1.2751975389999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page77.pdf" ],
+    "diameter_mm" : 11.48,
+    "diameter_inch" : 0.451968748
+  },
+  "45 Colt" : {
+    "name" : "45 Colt",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 40.64,
+      "coal_inch" : 1.6000008639999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page78.pdf" ],
+    "diameter_mm" : 11.58,
+    "diameter_inch" : 0.455905758
+  },
+  "45 Colt (carb)" : {
+    "name" : "45 Colt (carb)",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page79.pdf" ],
+    "diameter_mm" : 12.19,
+    "diameter_inch" : 0.47992151899999996
+  },
+  "45 Glock Auto Pistol" : {
+    "name" : "45 Glock Auto Pistol",
+    "names" : [ "45 GAP" ],
+    "specs" : {
+      "coal_mm" : 28.89,
+      "coal_inch" : 1.137402189
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/45-gap-en.pdf" ],
+    "diameter_mm" : 11.48,
+    "diameter_inch" : 0.451968748
+  },
+  "45 HP" : {
+    "name" : "45 HP",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 31.4,
+      "coal_inch" : 1.2362211399999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page81.pdf" ],
+    "diameter_mm" : 11.48,
+    "diameter_inch" : 0.451968748
+  },
+  "45 Smith & Wesson Schofield" : {
+    "name" : "45 Smith & Wesson Schofield",
+    "names" : [ "45 S&W Schofield" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page82.pdf" ]
+  },
+  "45 Smith & Wesson Schofield (carb)" : {
+    "name" : "45 Smith & Wesson Schofield (carb)",
+    "names" : [ "45 S&W Schofield (carb)" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page83.pdf" ],
+    "diameter_mm" : 12.19,
+    "diameter_inch" : 0.47992151899999996
+  },
+  "45 Winchester Magnum" : {
+    "name" : "45 Winchester Magnum",
+    "names" : [ "45 Win. Mag." ],
+    "specs" : {
+      "coal_mm" : 40.01,
+      "coal_inch" : 1.5751977009999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page84.pdf" ],
+    "diameter_mm" : 11.48,
+    "diameter_inch" : 0.451968748
+  },
+  "450 SCH" : {
+    "name" : "450 SCH",
+    "names" : [ "450 Schuster" ],
+    "specs" : {
+      "coal_mm" : 32.39,
+      "coal_inch" : 1.2751975389999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/450-sch-en.pdf" ],
+    "diameter_mm" : 11.48,
+    "diameter_inch" : 0.451968748
+  },
+  "450 Short" : {
+    "name" : "450 Short",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 28.5,
+      "coal_inch" : 1.12204785
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page85.pdf" ],
+    "diameter_mm" : 11.58,
+    "diameter_inch" : 0.455905758
+  },
+  "454 Casull" : {
+    "name" : "454 Casull",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 44.83,
+      "coal_inch" : 1.7649615829999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/454-casull-en.pdf" ],
+    "diameter_mm" : 11.49,
+    "diameter_inch" : 0.452362449
+  },
+  "455 MK II" : {
+    "name" : "455 MK II",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 32.0,
+      "coal_inch" : 1.2598432
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page87.pdf" ],
+    "diameter_mm" : 11.57,
+    "diameter_inch" : 0.45551205699999997
+  },
+  "460 Smith & Wesson Magnum" : {
+    "name" : "460 Smith & Wesson Magnum",
+    "names" : [ "460 S&W Mag." ],
+    "specs" : {
+      "coal_mm" : 58.12,
+      "coal_inch" : 2.288190212
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page88.pdf" ],
+    "diameter_mm" : 11.49,
+    "diameter_inch" : 0.452362449
+  },
+  "475 Linebaugh" : {
+    "name" : "475 Linebaugh",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 44.43,
+      "coal_inch" : 1.749213543
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page89.pdf" ],
+    "diameter_mm" : 12.08,
+    "diameter_inch" : 0.475590808
+  },
+  "480 Ruger" : {
+    "name" : "480 Ruger",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 41.91,
+      "coal_inch" : 1.6500008909999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/480-ruger-en.pdf" ],
+    "diameter_mm" : 12.08,
+    "diameter_inch" : 0.475590808
+  },
+  "5.45 x 18" : {
+    "name" : "5.45 x 18",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 25.0,
+      "coal_inch" : 0.9842525
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page2.pdf" ],
+    "diameter_mm" : 5.63,
+    "diameter_inch" : 0.22165366299999997
+  },
+  "5.75 Velodog" : {
+    "name" : "5.75 Velodog",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 35.6,
+      "coal_inch" : 1.40157556
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page3.pdf" ],
+    "diameter_mm" : 5.79,
+    "diameter_inch" : 0.227952879
+  },
+  "50 Action Express" : {
+    "name" : "50 Action Express",
+    "names" : [ "50 AE" ],
+    "specs" : {
+      "coal_mm" : 40.5,
+      "coal_inch" : 1.59448905
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page91.pdf" ],
+    "diameter_mm" : 12.71,
+    "diameter_inch" : 0.500393971
+  },
+  "500 Smith & Wesson Magnum" : {
+    "name" : "500 Smith & Wesson Magnum",
+    "names" : [ "500 S&W Mag." ],
+    "specs" : {
+      "coal_mm" : 58.42,
+      "coal_inch" : 2.300001242
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/500-s-w-mag-en.pdf" ],
+    "diameter_mm" : 12.7,
+    "diameter_inch" : 0.5000002699999999
+  },
+  "6.35 Browning" : {
+    "name" : "6.35 Browning",
+    "names" : [ "25 Auto(matic)", "25 ACP" ],
+    "specs" : {
+      "coal_mm" : 23.0,
+      "coal_inch" : 0.9055122999999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page4.pdf" ],
+    "diameter_mm" : 6.38,
+    "diameter_inch" : 0.251181238
+  },
+  "7 Penna" : {
+    "name" : "7 Penna",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 34.5,
+      "coal_inch" : 1.35826845
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page6.pdf" ],
+    "diameter_mm" : 7.04,
+    "diameter_inch" : 0.277165504
+  },
+  "7 x 49 Guido J. Wasser" : {
+    "name" : "7 x 49 Guido J. Wasser",
+    "names" : [ "7 x 49 GJW" ],
+    "specs" : {
+      "coal_mm" : 73.5,
+      "coal_inch" : 2.89370235
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page5.pdf" ],
+    "diameter_mm" : 7.25,
+    "diameter_inch" : 0.285433225
+  },
+  "7.5 FK" : {
+    "name" : "7.5 FK",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 35.0,
+      "coal_inch" : 1.3779534999999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/7-5-fk-en.pdf" ],
+    "diameter_mm" : 7.8,
+    "diameter_inch" : 0.30708678
+  },
+  "7.5 Ordonnance Suisse" : {
+    "name" : "7.5 Ordonnance Suisse",
+    "names" : [ "7.5 Ord. Suisse" ],
+    "specs" : {
+      "coal_mm" : 34.6,
+      "coal_inch" : 1.36220546
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page8.pdf" ],
+    "diameter_mm" : 8.0,
+    "diameter_inch" : 0.3149608
+  },
+  "7.62 Nagant" : {
+    "name" : "7.62 Nagant",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 37.3,
+      "coal_inch" : 1.4685047299999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page10.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "7.62 x 25 Tokarev" : {
+    "name" : "7.62 x 25 Tokarev",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 35.2,
+      "coal_inch" : 1.38582752
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page9.pdf" ],
+    "diameter_mm" : 7.9,
+    "diameter_inch" : 0.31102379
+  },
+  "7.63 Mauser" : {
+    "name" : "7.63 Mauser",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 35.08,
+      "coal_inch" : 1.3811031079999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/7-63-mauser-en.pdf" ],
+    "diameter_mm" : 7.86,
+    "diameter_inch" : 0.309448986
+  },
+  "7.65 Browning" : {
+    "name" : "7.65 Browning",
+    "names" : [ "32 Auto(matic)", "32 ACP" ],
+    "specs" : {
+      "coal_mm" : 25.0,
+      "coal_inch" : 0.9842525
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page12.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "7.65 Long" : {
+    "name" : "7.65 Long",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 30.5,
+      "coal_inch" : 1.2007880499999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page13.pdf" ],
+    "diameter_mm" : 7.88,
+    "diameter_inch" : 0.310236388
+  },
+  "7.65 Parabellum" : {
+    "name" : "7.65 Parabellum",
+    "names" : [ "7,65 Para", "7,65 Luger", "30 Luger" ],
+    "specs" : {
+      "coal_mm" : 29.85,
+      "coal_inch" : 1.175197485
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page14.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "7mm Penna L" : {
+    "name" : "7mm Penna L",
+    "names" : [ "7 mm Penna L" ],
+    "specs" : {
+      "coal_mm" : 41.0,
+      "coal_inch" : 1.6141740999999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page7.pdf" ],
+    "diameter_mm" : 7.04,
+    "diameter_inch" : 0.277165504
+  },
+  "8mm Gasser" : {
+    "name" : "8mm Gasser",
+    "names" : [ "8 mm Gasser" ],
+    "specs" : {
+      "coal_mm" : 36.0,
+      "coal_inch" : 1.4173236
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page15.pdf" ],
+    "diameter_mm" : 8.11,
+    "diameter_inch" : 0.319291511
+  },
+  "8mm Lebel" : {
+    "name" : "8mm Lebel",
+    "names" : [ "8 mm Lebel" ],
+    "specs" : {
+      "coal_mm" : 37.0,
+      "coal_inch" : 1.4566937
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page16.pdf" ],
+    "diameter_mm" : 8.28,
+    "diameter_inch" : 0.32598442799999994
+  },
+  "8mm Steyr" : {
+    "name" : "8mm Steyr",
+    "names" : [ "8 mm Steyr" ],
+    "specs" : {
+      "coal_mm" : 28.7,
+      "coal_inch" : 1.12992187
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page17.pdf" ],
+    "diameter_mm" : 8.15,
+    "diameter_inch" : 0.320866315
+  },
+  "9 x 18" : {
+    "name" : "9 x 18",
+    "names" : [ "9 x 18 Ultra", "9mm Police" ],
+    "specs" : {
+      "coal_mm" : 25.5,
+      "coal_inch" : 1.0039375499999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page18.pdf" ],
+    "diameter_mm" : 9.02,
+    "diameter_inch" : 0.35511830199999994
+  },
+  "9 x 20 VGW" : {
+    "name" : "9 x 20 VGW",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 30.69,
+      "coal_inch" : 1.208268369
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page19.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  },
+  "9 x 21" : {
+    "name" : "9 x 21",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 29.75,
+      "coal_inch" : 1.171260475
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page20.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  },
+  "9 x 22 Major" : {
+    "name" : "9 x 22 Major",
+    "names" : [ "9 x 22 MJR" ],
+    "specs" : {
+      "coal_mm" : 29.0,
+      "coal_inch" : 1.1417329
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page21.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  },
+  "9 x 25 Super Automatic G" : {
+    "name" : "9 x 25 Super Automatic G",
+    "names" : [ "9 x 25 Super Auto G" ],
+    "specs" : {
+      "coal_mm" : 32.7,
+      "coal_inch" : 1.28740227
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/9-x-25-super-auto-g-en.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  },
+  "9mm Browning court" : {
+    "name" : "9mm Browning court",
+    "names" : [ "9mm Browning Kurz (short", "corto)", "9 mm kurz", "380 ACP", "380 Auto(matic)", "9 mm Browning court" ],
+    "specs" : {
+      "coal_mm" : 25.0,
+      "coal_inch" : 0.9842525
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page24.pdf" ],
+    "diameter_mm" : 9.04,
+    "diameter_inch" : 0.35590570399999993
+  },
+  "9mm Browning long" : {
+    "name" : "9mm Browning long",
+    "names" : [ "9 mm Browning long" ],
+    "specs" : {
+      "coal_mm" : 28.0,
+      "coal_inch" : 1.1023627999999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page25.pdf" ],
+    "diameter_mm" : 9.09,
+    "diameter_inch" : 0.357874209
+  },
+  "9mm FX & CQT" : {
+    "name" : "9mm FX & CQT",
+    "names" : [ "9 mm FX & CQT" ],
+    "specs" : {
+      "coal_mm" : 29.03,
+      "coal_inch" : 1.142914003
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page27.pdf" ],
+    "diameter_mm" : 7.72,
+    "diameter_inch" : 0.303937172
+  },
+  "9mm Fast Accurate Reliable" : {
+    "name" : "9mm Fast Accurate Reliable",
+    "names" : [ "9 mm FAR" ],
+    "specs" : {
+      "coal_mm" : 32.6,
+      "coal_inch" : 1.28346526
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page26.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  },
+  "9mm Luger" : {
+    "name" : "9mm Luger",
+    "names" : [ "9 mm Para(bellum)", "9 x 19 (mm)", "9 mm Luger" ],
+    "specs" : {
+      "coal_mm" : 29.69,
+      "coal_inch" : 1.168898269
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page28.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  },
+  "9mm Makarov" : {
+    "name" : "9mm Makarov",
+    "names" : [ "9 mm Makarov" ],
+    "specs" : {
+      "coal_mm" : 25.0,
+      "coal_inch" : 0.9842525
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page23.pdf" ],
+    "diameter_mm" : 9.27,
+    "diameter_inch" : 0.364960827
+  },
+  "9mm Mauser" : {
+    "name" : "9mm Mauser",
+    "names" : [ "9 mm Mauser" ],
+    "specs" : {
+      "coal_mm" : 35.0,
+      "coal_inch" : 1.3779534999999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/9-mm-mauser-en.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  },
+  "9mm Steyr" : {
+    "name" : "9mm Steyr",
+    "names" : [ "9 mm Steyr" ],
+    "specs" : {
+      "coal_mm" : 33.1,
+      "coal_inch" : 1.30315031
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page29.pdf" ],
+    "diameter_mm" : 9.03,
+    "diameter_inch" : 0.35551200299999997
+  }
 }

--- a/data/pistol/cip.json
+++ b/data/pistol/cip.json
@@ -3,133 +3,111 @@
     "name" : "10 x 22 T",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 22.7,
-      "coal_inch" : 0.8937012699999999
+      "coal_mm" : "22.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page30.pdf" ],
-    "diameter_mm" : 10.0,
-    "diameter_inch" : 0.39370099999999997
+    "diameter_mm" : "10.0"
   },
   "10.4 Ordinanza Italiana" : {
     "name" : "10.4 Ordinanza Italiana",
     "names" : [ "10.4 Ord. It." ],
     "specs" : {
-      "coal_mm" : 30.2,
-      "coal_inch" : 1.1889770199999998
+      "coal_mm" : "30.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page33.pdf" ],
-    "diameter_mm" : 11.1,
-    "diameter_inch" : 0.43700810999999995
+    "diameter_mm" : "11.1"
   },
   "10mm Automatic" : {
     "name" : "10mm Automatic",
     "names" : [ "10 mm Auto" ],
     "specs" : {
-      "coal_mm" : 32.0,
-      "coal_inch" : 1.2598432
+      "coal_mm" : "32.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/10-mm-auto-en.pdf" ],
-    "diameter_mm" : 10.17,
-    "diameter_inch" : 0.400393917
+    "diameter_mm" : "10.17"
   },
   "10mm Fast Accurate Reliable" : {
     "name" : "10mm Fast Accurate Reliable",
     "names" : [ "10 mm FAR" ],
     "specs" : {
-      "coal_mm" : 32.2,
-      "coal_inch" : 1.26771722
+      "coal_mm" : "32.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page32.pdf" ],
-    "diameter_mm" : 10.17,
-    "diameter_inch" : 0.400393917
+    "diameter_mm" : "10.17"
   },
   "11mm 73" : {
     "name" : "11mm 73",
     "names" : [ "11 mm 73" ],
     "specs" : {
-      "coal_mm" : 29.65,
-      "coal_inch" : 1.167323465
+      "coal_mm" : "29.65"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/11-mm-73-en.pdf" ],
-    "diameter_mm" : 11.6,
-    "diameter_inch" : 0.45669316
+    "diameter_mm" : "11.6"
   },
   "22 PICRA" : {
     "name" : "22 PICRA",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 48.0,
-      "coal_inch" : 1.8897648
+      "coal_mm" : "48.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page35.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "22 Remington Jet Magnum" : {
     "name" : "22 Remington Jet Magnum",
     "names" : [ "22 Rem.Jet Mag." ],
     "specs" : {
-      "coal_mm" : 42.14,
-      "coal_inch" : 1.659056014
+      "coal_mm" : "42.14"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page36.pdf" ],
-    "diameter_mm" : 5.65,
-    "diameter_inch" : 0.222441065
+    "diameter_mm" : "5.65"
   },
   "221 Remington Fireball" : {
     "name" : "221 Remington Fireball",
     "names" : [ "221 Rem. Fireball" ],
     "specs" : {
-      "coal_mm" : 46.48,
-      "coal_inch" : 1.8299222479999997
+      "coal_mm" : "46.48"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page37.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "260 PICRA" : {
     "name" : "260 PICRA",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 62.0,
-      "coal_inch" : 2.4409462
+      "coal_mm" : "62.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page38.pdf" ],
-    "diameter_mm" : 6.71,
-    "diameter_inch" : 0.264173371
+    "diameter_mm" : "6.71"
   },
   "30 PICRA" : {
     "name" : "30 PICRA",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 56.0,
-      "coal_inch" : 2.2047255999999997
+      "coal_mm" : "56.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page39.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "30-357 Armi e Tiro" : {
     "name" : "30-357 Armi e Tiro",
     "names" : [ "30-357 AeT" ],
     "specs" : {
-      "coal_mm" : 47.8,
-      "coal_inch" : 1.8818907799999998
+      "coal_mm" : "47.8"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page40.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "32 Harrington & Richardson Magnum" : {
     "name" : "32 Harrington & Richardson Magnum",
@@ -142,109 +120,91 @@
     "name" : "32 Long Colt",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 30.89,
-      "coal_inch" : 1.216142389
+      "coal_mm" : "30.89"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page42.pdf" ],
-    "diameter_mm" : 7.97,
-    "diameter_inch" : 0.31377969699999997
+    "diameter_mm" : "7.97"
   },
   "32 Short Colt" : {
     "name" : "32 Short Colt",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 25.78,
-      "coal_inch" : 1.014961178
+      "coal_mm" : "25.78"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page43.pdf" ],
-    "diameter_mm" : 7.98,
-    "diameter_inch" : 0.314173398
+    "diameter_mm" : "7.98"
   },
   "32 Smith & Wesson" : {
     "name" : "32 Smith & Wesson",
     "names" : [ "32 S&W" ],
     "specs" : {
-      "coal_mm" : 23.62,
-      "coal_inch" : 0.929921762
+      "coal_mm" : "23.62"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page44.pdf" ],
-    "diameter_mm" : 8.0,
-    "diameter_inch" : 0.3149608
+    "diameter_mm" : "8.0"
   },
   "32 Smith & Wesson Long" : {
     "name" : "32 Smith & Wesson Long",
     "names" : [ "32 Colt New Police", "32 S&W Long" ],
     "specs" : {
-      "coal_mm" : 32.51,
-      "coal_inch" : 1.279921951
+      "coal_mm" : "32.51"
     },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page45.pdf" ],
-    "diameter_mm" : 8.0,
-    "diameter_inch" : 0.3149608
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/32s-w-long-190829-en.pdf" ],
+    "diameter_mm" : "8.0"
   },
   "32 Smith & Wesson Long Wad Cutter" : {
     "name" : "32 Smith & Wesson Long Wad Cutter",
     "names" : [ "32 S&W Long Wad Cut." ],
     "specs" : {
-      "coal_mm" : 25.4,
-      "coal_inch" : 1.0000005399999998
+      "coal_mm" : "25.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page46.pdf" ],
-    "diameter_mm" : 8.0,
-    "diameter_inch" : 0.3149608
+    "diameter_mm" : "8.0"
   },
   "320 Long" : {
     "name" : "320 Long",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 30.0,
-      "coal_inch" : 1.181103
+      "coal_mm" : "30.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page47.pdf" ],
-    "diameter_mm" : 7.7,
-    "diameter_inch" : 0.30314977
+    "diameter_mm" : "7.7"
   },
   "320 Short" : {
     "name" : "320 Short",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 26.7,
-      "coal_inch" : 1.0511816699999998
+      "coal_mm" : "26.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page48.pdf" ],
-    "diameter_mm" : 8.0,
-    "diameter_inch" : 0.3149608
+    "diameter_mm" : "8.0"
   },
   "357 Automatic Magnum" : {
     "name" : "357 Automatic Magnum",
     "names" : [ "357 Auto Mag." ],
     "specs" : {
-      "coal_mm" : 40.65,
-      "coal_inch" : 1.6003945649999998
+      "coal_mm" : "40.65"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page49.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "357 Magnum" : {
     "name" : "357 Magnum",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 40.39,
-      "coal_inch" : 1.590158339
+      "coal_mm" : "40.39"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/357-magnum-en.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "357 Magnum (carb)" : {
     "name" : "357 Magnum (carb)",
@@ -252,80 +212,67 @@
     "specs" : { },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/357-magnum-carb-en.pdf" ],
-    "diameter_mm" : 9.65,
-    "diameter_inch" : 0.379921465
+    "diameter_mm" : "9.65"
   },
   "357 Maximum" : {
     "name" : "357 Maximum",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 50.55,
-      "coal_inch" : 1.9901585549999998
+      "coal_mm" : "50.55"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page52.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "357 SIG" : {
     "name" : "357 SIG",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 28.96,
-      "coal_inch" : 1.140158096
+      "coal_mm" : "28.96"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page53.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   },
   "38 Long Colt" : {
     "name" : "38 Long Colt",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 34.54,
-      "coal_inch" : 1.3598432539999998
+      "coal_mm" : "34.54"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page54.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "38 Short Colt" : {
     "name" : "38 Short Colt",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 30.48,
-      "coal_inch" : 1.200000648
+      "coal_mm" : "30.48"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page55.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "38 Smith & Wesson. Colt New Police" : {
     "name" : "38 Smith & Wesson. Colt New Police",
     "names" : [ "38 S&W. Colt N.P." ],
     "specs" : {
-      "coal_mm" : 31.5,
-      "coal_inch" : 1.2401581499999998
+      "coal_mm" : "31.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page56.pdf" ],
-    "diameter_mm" : 9.17,
-    "diameter_inch" : 0.36102381699999997
+    "diameter_mm" : "9.17"
   },
   "38 Special" : {
     "name" : "38 Special",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 39.37,
-      "coal_inch" : 1.5500008369999998
+      "coal_mm" : "39.37"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page57.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "38 Special (carb)" : {
     "name" : "38 Special (carb)",
@@ -333,164 +280,137 @@
     "specs" : { },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page58.pdf" ],
-    "diameter_mm" : 9.65,
-    "diameter_inch" : 0.379921465
+    "diameter_mm" : "9.65"
   },
   "38 Special Army Marksmanship Unit" : {
     "name" : "38 Special Army Marksmanship Unit",
     "names" : [ "38 Spl. AMU" ],
     "specs" : {
-      "coal_mm" : 30.23,
-      "coal_inch" : 1.190158123
+      "coal_mm" : "30.23"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page59.pdf" ],
-    "diameter_mm" : 9.11,
-    "diameter_inch" : 0.35866161099999994
+    "diameter_mm" : "9.11"
   },
   "38 Special Wad Cutter" : {
     "name" : "38 Special Wad Cutter",
     "names" : [ "38 Spl. Wad Cut." ],
     "specs" : {
-      "coal_mm" : 30.35,
-      "coal_inch" : 1.194882535
+      "coal_mm" : "30.35"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page60.pdf" ],
-    "diameter_mm" : 9.14,
-    "diameter_inch" : 0.359842714
+    "diameter_mm" : "9.14"
   },
   "38 Super Automatic" : {
     "name" : "38 Super Automatic",
     "names" : [ "38 Super Auto" ],
     "specs" : {
-      "coal_mm" : 32.51,
-      "coal_inch" : 1.279921951
+      "coal_mm" : "32.51"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page61.pdf" ],
-    "diameter_mm" : 9.04,
-    "diameter_inch" : 0.35590570399999993
+    "diameter_mm" : "9.04"
   },
   "38-45 Automatic Colt Pistol" : {
     "name" : "38-45 Automatic Colt Pistol",
     "names" : [ "38-45 ACP" ],
     "specs" : {
-      "coal_mm" : 31.7,
-      "coal_inch" : 1.2480321699999999
+      "coal_mm" : "31.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page63.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "38/357 FX" : {
     "name" : "38/357 FX",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 30.99,
-      "coal_inch" : 1.2200793989999998
+      "coal_mm" : "30.99"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page62.pdf" ],
-    "diameter_mm" : 8.94,
-    "diameter_inch" : 0.35196869399999997
+    "diameter_mm" : "8.94"
   },
   "380 Long" : {
     "name" : "380 Long",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 35.0,
-      "coal_inch" : 1.3779534999999998
+      "coal_mm" : "35.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page64.pdf" ],
-    "diameter_mm" : 9.15,
-    "diameter_inch" : 0.360236415
+    "diameter_mm" : "9.15"
   },
   "380 Short" : {
     "name" : "380 Short",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 28.0,
-      "coal_inch" : 1.1023627999999999
+      "coal_mm" : "28.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page65.pdf" ],
-    "diameter_mm" : 9.15,
-    "diameter_inch" : 0.360236415
+    "diameter_mm" : "9.15"
   },
   "40 Smith & Wesson" : {
     "name" : "40 Smith & Wesson",
     "names" : [ "40 S&W" ],
     "specs" : {
-      "coal_mm" : 28.83,
-      "coal_inch" : 1.135039983
+      "coal_mm" : "28.83"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page66.pdf" ],
-    "diameter_mm" : 10.17,
-    "diameter_inch" : 0.400393917
+    "diameter_mm" : "10.17"
   },
   "41 Action Express" : {
     "name" : "41 Action Express",
     "names" : [ "41 ACT EXP" ],
     "specs" : {
-      "coal_mm" : 29.25,
-      "coal_inch" : 1.1515754249999999
+      "coal_mm" : "29.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page67.pdf" ],
-    "diameter_mm" : 10.41,
-    "diameter_inch" : 0.409842741
+    "diameter_mm" : "10.41"
   },
   "41 Long Colt" : {
     "name" : "41 Long Colt",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 36.19,
-      "coal_inch" : 1.424803919
+      "coal_mm" : "36.19"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page68.pdf" ],
-    "diameter_mm" : 9.86,
-    "diameter_inch" : 0.38818918599999996
+    "diameter_mm" : "9.86"
   },
   "41 Remington Magnum" : {
     "name" : "41 Remington Magnum",
     "names" : [ "41 Rem. Mag." ],
     "specs" : {
-      "coal_mm" : 40.39,
-      "coal_inch" : 1.590158339
+      "coal_mm" : "40.39"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page69.pdf" ],
-    "diameter_mm" : 10.41,
-    "diameter_inch" : 0.409842741
+    "diameter_mm" : "10.41"
   },
   "44 Colt" : {
     "name" : "44 Colt",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 38.1,
-      "coal_inch" : 1.50000081
+      "coal_mm" : "38.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page70.pdf" ],
-    "diameter_mm" : 11.25,
-    "diameter_inch" : 0.442913625
+    "diameter_mm" : "11.25"
   },
   "44 Remington Magnum" : {
     "name" : "44 Remington Magnum",
     "names" : [ "44 Rem. Mag." ],
     "specs" : {
-      "coal_mm" : 40.89,
-      "coal_inch" : 1.609843389
+      "coal_mm" : "40.89"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page71.pdf" ],
-    "diameter_mm" : 10.97,
-    "diameter_inch" : 0.431889997
+    "diameter_mm" : "10.97"
   },
   "44 Remington Magnum (carb)" : {
     "name" : "44 Remington Magnum (carb)",
@@ -498,8 +418,7 @@
     "specs" : { },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page72.pdf" ],
-    "diameter_mm" : 11.63,
-    "diameter_inch" : 0.457874263
+    "diameter_mm" : "11.63"
   },
   "44 Smith & Wesson Russian" : {
     "name" : "44 Smith & Wesson Russian",
@@ -526,37 +445,31 @@
     "name" : "45 Automatic",
     "names" : [ "45 Auto" ],
     "specs" : {
-      "coal_mm" : 32.39,
-      "coal_inch" : 1.2751975389999999
+      "coal_mm" : "32.39"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page76.pdf" ],
-    "diameter_mm" : 11.48,
-    "diameter_inch" : 0.451968748
+    "diameter_mm" : "11.48"
   },
   "45 Automatic Rim" : {
     "name" : "45 Automatic Rim",
     "names" : [ "45 Auto Rim" ],
     "specs" : {
-      "coal_mm" : 32.39,
-      "coal_inch" : 1.2751975389999999
+      "coal_mm" : "32.39"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page77.pdf" ],
-    "diameter_mm" : 11.48,
-    "diameter_inch" : 0.451968748
+    "diameter_mm" : "11.48"
   },
   "45 Colt" : {
     "name" : "45 Colt",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 40.64,
-      "coal_inch" : 1.6000008639999999
+      "coal_mm" : "40.64"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page78.pdf" ],
-    "diameter_mm" : 11.58,
-    "diameter_inch" : 0.455905758
+    "diameter_mm" : "11.58"
   },
   "45 Colt (carb)" : {
     "name" : "45 Colt (carb)",
@@ -564,32 +477,27 @@
     "specs" : { },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page79.pdf" ],
-    "diameter_mm" : 12.19,
-    "diameter_inch" : 0.47992151899999996
+    "diameter_mm" : "12.19"
   },
   "45 Glock Auto Pistol" : {
     "name" : "45 Glock Auto Pistol",
     "names" : [ "45 GAP" ],
     "specs" : {
-      "coal_mm" : 28.89,
-      "coal_inch" : 1.137402189
+      "coal_mm" : "28.89"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/45-gap-en.pdf" ],
-    "diameter_mm" : 11.48,
-    "diameter_inch" : 0.451968748
+    "diameter_mm" : "11.48"
   },
   "45 HP" : {
     "name" : "45 HP",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 31.4,
-      "coal_inch" : 1.2362211399999998
+      "coal_mm" : "31.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page81.pdf" ],
-    "diameter_mm" : 11.48,
-    "diameter_inch" : 0.451968748
+    "diameter_mm" : "11.48"
   },
   "45 Smith & Wesson Schofield" : {
     "name" : "45 Smith & Wesson Schofield",
@@ -604,487 +512,406 @@
     "specs" : { },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page83.pdf" ],
-    "diameter_mm" : 12.19,
-    "diameter_inch" : 0.47992151899999996
+    "diameter_mm" : "12.19"
   },
   "45 Winchester Magnum" : {
     "name" : "45 Winchester Magnum",
     "names" : [ "45 Win. Mag." ],
     "specs" : {
-      "coal_mm" : 40.01,
-      "coal_inch" : 1.5751977009999998
+      "coal_mm" : "40.01"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page84.pdf" ],
-    "diameter_mm" : 11.48,
-    "diameter_inch" : 0.451968748
+    "diameter_mm" : "11.48"
   },
   "450 SCH" : {
     "name" : "450 SCH",
     "names" : [ "450 Schuster" ],
     "specs" : {
-      "coal_mm" : 32.39,
-      "coal_inch" : 1.2751975389999999
+      "coal_mm" : "32.39"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/450-sch-en.pdf" ],
-    "diameter_mm" : 11.48,
-    "diameter_inch" : 0.451968748
+    "diameter_mm" : "11.48"
   },
   "450 Short" : {
     "name" : "450 Short",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 28.5,
-      "coal_inch" : 1.12204785
+      "coal_mm" : "28.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page85.pdf" ],
-    "diameter_mm" : 11.58,
-    "diameter_inch" : 0.455905758
+    "diameter_mm" : "11.58"
   },
   "454 Casull" : {
     "name" : "454 Casull",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 44.83,
-      "coal_inch" : 1.7649615829999998
+      "coal_mm" : "44.83"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/454-casull-en.pdf" ],
-    "diameter_mm" : 11.49,
-    "diameter_inch" : 0.452362449
+    "diameter_mm" : "11.49"
   },
   "455 MK II" : {
     "name" : "455 MK II",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 32.0,
-      "coal_inch" : 1.2598432
+      "coal_mm" : "32.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page87.pdf" ],
-    "diameter_mm" : 11.57,
-    "diameter_inch" : 0.45551205699999997
+    "diameter_mm" : "11.57"
   },
   "460 Smith & Wesson Magnum" : {
     "name" : "460 Smith & Wesson Magnum",
     "names" : [ "460 S&W Mag." ],
     "specs" : {
-      "coal_mm" : 58.12,
-      "coal_inch" : 2.288190212
+      "coal_mm" : "58.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page88.pdf" ],
-    "diameter_mm" : 11.49,
-    "diameter_inch" : 0.452362449
+    "diameter_mm" : "11.49"
   },
   "475 Linebaugh" : {
     "name" : "475 Linebaugh",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 44.43,
-      "coal_inch" : 1.749213543
+      "coal_mm" : "44.43"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page89.pdf" ],
-    "diameter_mm" : 12.08,
-    "diameter_inch" : 0.475590808
+    "diameter_mm" : "12.08"
   },
   "480 Ruger" : {
     "name" : "480 Ruger",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 41.91,
-      "coal_inch" : 1.6500008909999997
+      "coal_mm" : "41.91"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/480-ruger-en.pdf" ],
-    "diameter_mm" : 12.08,
-    "diameter_inch" : 0.475590808
+    "diameter_mm" : "12.08"
   },
   "5.45 x 18" : {
     "name" : "5.45 x 18",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 25.0,
-      "coal_inch" : 0.9842525
+      "coal_mm" : "25.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page2.pdf" ],
-    "diameter_mm" : 5.63,
-    "diameter_inch" : 0.22165366299999997
+    "diameter_mm" : "5.63"
   },
   "5.75 Velodog" : {
     "name" : "5.75 Velodog",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 35.6,
-      "coal_inch" : 1.40157556
+      "coal_mm" : "35.6"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page3.pdf" ],
-    "diameter_mm" : 5.79,
-    "diameter_inch" : 0.227952879
+    "diameter_mm" : "5.79"
   },
   "50 Action Express" : {
     "name" : "50 Action Express",
     "names" : [ "50 AE" ],
     "specs" : {
-      "coal_mm" : 40.5,
-      "coal_inch" : 1.59448905
+      "coal_mm" : "40.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page91.pdf" ],
-    "diameter_mm" : 12.71,
-    "diameter_inch" : 0.500393971
+    "diameter_mm" : "12.71"
   },
   "500 Smith & Wesson Magnum" : {
     "name" : "500 Smith & Wesson Magnum",
     "names" : [ "500 S&W Mag." ],
     "specs" : {
-      "coal_mm" : 58.42,
-      "coal_inch" : 2.300001242
+      "coal_mm" : "58.42"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/500-s-w-mag-en.pdf" ],
-    "diameter_mm" : 12.7,
-    "diameter_inch" : 0.5000002699999999
+    "diameter_mm" : "12.7"
   },
   "6.35 Browning" : {
     "name" : "6.35 Browning",
     "names" : [ "25 Auto(matic)", "25 ACP" ],
     "specs" : {
-      "coal_mm" : 23.0,
-      "coal_inch" : 0.9055122999999999
+      "coal_mm" : "23.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page4.pdf" ],
-    "diameter_mm" : 6.38,
-    "diameter_inch" : 0.251181238
+    "diameter_mm" : "6.38"
   },
   "7 Penna" : {
     "name" : "7 Penna",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 34.5,
-      "coal_inch" : 1.35826845
+      "coal_mm" : "34.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page6.pdf" ],
-    "diameter_mm" : 7.04,
-    "diameter_inch" : 0.277165504
+    "diameter_mm" : "7.04"
   },
   "7 x 49 Guido J. Wasser" : {
     "name" : "7 x 49 Guido J. Wasser",
     "names" : [ "7 x 49 GJW" ],
     "specs" : {
-      "coal_mm" : 73.5,
-      "coal_inch" : 2.89370235
+      "coal_mm" : "73.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page5.pdf" ],
-    "diameter_mm" : 7.25,
-    "diameter_inch" : 0.285433225
+    "diameter_mm" : "7.25"
   },
   "7.5 FK" : {
     "name" : "7.5 FK",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 35.0,
-      "coal_inch" : 1.3779534999999998
+      "coal_mm" : "35.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/7-5-fk-en.pdf" ],
-    "diameter_mm" : 7.8,
-    "diameter_inch" : 0.30708678
+    "diameter_mm" : "7.8"
   },
   "7.5 Ordonnance Suisse" : {
     "name" : "7.5 Ordonnance Suisse",
     "names" : [ "7.5 Ord. Suisse" ],
     "specs" : {
-      "coal_mm" : 34.6,
-      "coal_inch" : 1.36220546
+      "coal_mm" : "34.6"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page8.pdf" ],
-    "diameter_mm" : 8.0,
-    "diameter_inch" : 0.3149608
+    "diameter_mm" : "8.0"
   },
   "7.62 Nagant" : {
     "name" : "7.62 Nagant",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 37.3,
-      "coal_inch" : 1.4685047299999998
+      "coal_mm" : "37.3"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page10.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "7.62 x 25 Tokarev" : {
     "name" : "7.62 x 25 Tokarev",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 35.2,
-      "coal_inch" : 1.38582752
+      "coal_mm" : "35.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page9.pdf" ],
-    "diameter_mm" : 7.9,
-    "diameter_inch" : 0.31102379
+    "diameter_mm" : "7.9"
   },
   "7.63 Mauser" : {
     "name" : "7.63 Mauser",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 35.08,
-      "coal_inch" : 1.3811031079999998
+      "coal_mm" : "35.08"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/7-63-mauser-en.pdf" ],
-    "diameter_mm" : 7.86,
-    "diameter_inch" : 0.309448986
+    "diameter_mm" : "7.86"
   },
   "7.65 Browning" : {
     "name" : "7.65 Browning",
     "names" : [ "32 Auto(matic)", "32 ACP" ],
     "specs" : {
-      "coal_mm" : 25.0,
-      "coal_inch" : 0.9842525
+      "coal_mm" : "25.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page12.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "7.65 Long" : {
     "name" : "7.65 Long",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 30.5,
-      "coal_inch" : 1.2007880499999999
+      "coal_mm" : "30.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page13.pdf" ],
-    "diameter_mm" : 7.88,
-    "diameter_inch" : 0.310236388
+    "diameter_mm" : "7.88"
   },
   "7.65 Parabellum" : {
     "name" : "7.65 Parabellum",
     "names" : [ "7,65 Para", "7,65 Luger", "30 Luger" ],
     "specs" : {
-      "coal_mm" : 29.85,
-      "coal_inch" : 1.175197485
+      "coal_mm" : "29.85"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page14.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "7mm Penna L" : {
     "name" : "7mm Penna L",
     "names" : [ "7 mm Penna L" ],
     "specs" : {
-      "coal_mm" : 41.0,
-      "coal_inch" : 1.6141740999999998
+      "coal_mm" : "41.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page7.pdf" ],
-    "diameter_mm" : 7.04,
-    "diameter_inch" : 0.277165504
+    "diameter_mm" : "7.04"
   },
   "8mm Gasser" : {
     "name" : "8mm Gasser",
     "names" : [ "8 mm Gasser" ],
     "specs" : {
-      "coal_mm" : 36.0,
-      "coal_inch" : 1.4173236
+      "coal_mm" : "36.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page15.pdf" ],
-    "diameter_mm" : 8.11,
-    "diameter_inch" : 0.319291511
+    "diameter_mm" : "8.11"
   },
   "8mm Lebel" : {
     "name" : "8mm Lebel",
     "names" : [ "8 mm Lebel" ],
     "specs" : {
-      "coal_mm" : 37.0,
-      "coal_inch" : 1.4566937
+      "coal_mm" : "37.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page16.pdf" ],
-    "diameter_mm" : 8.28,
-    "diameter_inch" : 0.32598442799999994
+    "diameter_mm" : "8.28"
   },
   "8mm Steyr" : {
     "name" : "8mm Steyr",
     "names" : [ "8 mm Steyr" ],
     "specs" : {
-      "coal_mm" : 28.7,
-      "coal_inch" : 1.12992187
+      "coal_mm" : "28.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page17.pdf" ],
-    "diameter_mm" : 8.15,
-    "diameter_inch" : 0.320866315
+    "diameter_mm" : "8.15"
   },
   "9 x 18" : {
     "name" : "9 x 18",
     "names" : [ "9 x 18 Ultra", "9mm Police" ],
     "specs" : {
-      "coal_mm" : 25.5,
-      "coal_inch" : 1.0039375499999998
+      "coal_mm" : "25.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page18.pdf" ],
-    "diameter_mm" : 9.02,
-    "diameter_inch" : 0.35511830199999994
+    "diameter_mm" : "9.02"
   },
   "9 x 20 VGW" : {
     "name" : "9 x 20 VGW",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 30.69,
-      "coal_inch" : 1.208268369
+      "coal_mm" : "30.69"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page19.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   },
   "9 x 21" : {
     "name" : "9 x 21",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 29.75,
-      "coal_inch" : 1.171260475
+      "coal_mm" : "29.75"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page20.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   },
   "9 x 22 Major" : {
     "name" : "9 x 22 Major",
     "names" : [ "9 x 22 MJR" ],
     "specs" : {
-      "coal_mm" : 29.0,
-      "coal_inch" : 1.1417329
+      "coal_mm" : "29.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page21.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   },
   "9 x 25 Super Automatic G" : {
     "name" : "9 x 25 Super Automatic G",
     "names" : [ "9 x 25 Super Auto G" ],
     "specs" : {
-      "coal_mm" : 32.7,
-      "coal_inch" : 1.28740227
+      "coal_mm" : "32.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/9-x-25-super-auto-g-en.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   },
   "9mm Browning court" : {
     "name" : "9mm Browning court",
     "names" : [ "9mm Browning Kurz (short", "corto)", "9 mm kurz", "380 ACP", "380 Auto(matic)", "9 mm Browning court" ],
     "specs" : {
-      "coal_mm" : 25.0,
-      "coal_inch" : 0.9842525
+      "coal_mm" : "25.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page24.pdf" ],
-    "diameter_mm" : 9.04,
-    "diameter_inch" : 0.35590570399999993
+    "diameter_mm" : "9.04"
   },
   "9mm Browning long" : {
     "name" : "9mm Browning long",
     "names" : [ "9 mm Browning long" ],
     "specs" : {
-      "coal_mm" : 28.0,
-      "coal_inch" : 1.1023627999999999
+      "coal_mm" : "28.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page25.pdf" ],
-    "diameter_mm" : 9.09,
-    "diameter_inch" : 0.357874209
+    "diameter_mm" : "9.09"
   },
   "9mm FX & CQT" : {
     "name" : "9mm FX & CQT",
     "names" : [ "9 mm FX & CQT" ],
     "specs" : {
-      "coal_mm" : 29.03,
-      "coal_inch" : 1.142914003
+      "coal_mm" : "29.03"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page27.pdf" ],
-    "diameter_mm" : 7.72,
-    "diameter_inch" : 0.303937172
+    "diameter_mm" : "7.72"
   },
   "9mm Fast Accurate Reliable" : {
     "name" : "9mm Fast Accurate Reliable",
     "names" : [ "9 mm FAR" ],
     "specs" : {
-      "coal_mm" : 32.6,
-      "coal_inch" : 1.28346526
+      "coal_mm" : "32.6"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page26.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   },
   "9mm Luger" : {
     "name" : "9mm Luger",
     "names" : [ "9 mm Para(bellum)", "9 x 19 (mm)", "9 mm Luger" ],
     "specs" : {
-      "coal_mm" : 29.69,
-      "coal_inch" : 1.168898269
+      "coal_mm" : "29.69"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page28.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   },
   "9mm Makarov" : {
     "name" : "9mm Makarov",
     "names" : [ "9 mm Makarov" ],
     "specs" : {
-      "coal_mm" : 25.0,
-      "coal_inch" : 0.9842525
+      "coal_mm" : "25.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page23.pdf" ],
-    "diameter_mm" : 9.27,
-    "diameter_inch" : 0.364960827
+    "diameter_mm" : "9.27"
   },
   "9mm Mauser" : {
     "name" : "9mm Mauser",
     "names" : [ "9 mm Mauser" ],
     "specs" : {
-      "coal_mm" : 35.0,
-      "coal_inch" : 1.3779534999999998
+      "coal_mm" : "35.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/9-mm-mauser-en.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   },
   "9mm Steyr" : {
     "name" : "9mm Steyr",
     "names" : [ "9 mm Steyr" ],
     "specs" : {
-      "coal_mm" : 33.1,
-      "coal_inch" : 1.30315031
+      "coal_mm" : "33.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iv/tabivcal-en-page29.pdf" ],
-    "diameter_mm" : 9.03,
-    "diameter_inch" : 0.35551200299999997
+    "diameter_mm" : "9.03"
   }
 }

--- a/data/rifle/cip.json
+++ b/data/rifle/cip.json
@@ -1,371 +1,4389 @@
 {
-    "215": {},
-    "4.6 x 30": {},
-    "5mm / 35 SMc": {},
-    "5.45 x 39": {},
-    "5.6 x 39": {},
-    "5.6 x 50 Magnum": {},
-    "5.6 x 57": {},
-    "5.6 x 61 Super Express Vom Hofe": {},
-    "5.7 x 28": {},
-    "6 x 47 ATZL": {},
-    "6 x 47 SM": {},
-    "6 x 51 ATZL": {},
-    "6 x 62 Freres": {},
-    "6mm Bench Rest Farè": {},
-    "6mm Bench Rest Norma": {},
-    "6mm Bench Rest Remington": {},
-    "6mm D.B.G.": {},
-    "6mm Palmisano & Pindel Cartridge": {},
-    "6mm Palmisano & Pindel Cartridge ITA": {},
-    "6mm Palmisano & Pindel Cartridge-USA": {},
-    "6mm Remington (244 Remington)": {},
-    "6 XC": {},
-    "6.3 x 57 Farè": {},
-    "6.5 - 284 Norma": {},
-    "6.5 x 39": {},
-    "6.5 x 47 Lapua": {},
-    "6.5 x 52 Carcano": {},
-    "6.5 x 54 Mauser": {},
-    "6.5 x 54 Mannlicher–Schönauer": {},
-    "6.5 x 55 SE": {},
-    "6.5 x 55 T.R.I.": {},
-    "6.5 x 57": {},
-    "6.5 x 58 Mauser": {},
-    "6.5 x 63 Messner Magnum": {},
-    "6.5 x 64": {},
-    "6.5 x 64 Brenneke": {},
-    "6.5 x 65 Rheinisch-Westfälischen Sprengstoff-Fabriken": {},
-    "6.5 x 68": {},
-    "6.5 Creedmoor": {},
-    "6.5 Grendel": {},
-    "6.5mm D.B.G.": {},
-    "6.5mm Lahoz": {},
-    "6.8mm Remington Special Purpose Cartridge": {},
-    "7 x 33 Sako": {},
-    "7 x 44 Penna": {},
-    "7 x 57": {},
-    "7 x 64": {},
-    "7-47 Giani Special": {},
-    "7mm - 08 Remington": {},
-    "7mm Blaser Magnum": {},
-    "7mm Bench Rest Remington": {},
-    "7mm Express Remington": {},
-    "7mm KM": {},
-    "7mm Remington Short Action Ultra Magnum": {},
-    "7mm Remington Ultra Magnum": {},
-    "7mm Super Express Vom Hofe": {},
-    "7mm Winchester Short Magnum": {},
-    "7.21 Firebird": {},
-    "7.5 x 54 Manufacture d'armes de Saint-Étienne": {},
-    "7.5 x 55 Suisse": {},
-    "7.62 x 39": {},
-    "7.62 x 45": {},
-    "7.62 Uekötter Katzmeier Magnum": {},
-    "7.65 x 53 Argentine": {},
-    "7.82 Warbird": {},
-    "7.92 x 24 Van Bruaene Rik": {},
-    "7.92 x 33 kurz": {},
-    "8 x 51 (Mauser K)": {},
-    "8 x 56 Mannlicher–Schönauer": {},
-    "8 x 57 I": {},
-    "8 x 57 IS": {},
-    "8 x 57 PCC": {},
-    "8 x 60": {},
-    "8 x 60 S": {},
-    "8 x 64": {},
-    "8 x 64 S": {},
-    "8 x 68 S": {},
-    "8 x 75 S": {},
-    "8.5 x 63": {},
-    "8.5 x 68 Fanzoj": {},
-    "8.5mm Messner Magnum": {},
-    "9 x 56 Mannlicher–Schönauer": {},
-    "9 x 57": {},
-    "9.3 x 57": {},
-    "9.3 x 62": {},
-    "9.3 x 64 Brenneke": {},
-    "9.3 x 66 Sako": {},
-    "9.3 Roedale Short Magnum": {},
-    "9.5 x 57 Mannlicher–Schönauer": {},
-    "9.5 x 66 Super Express Vom Hofe": {},
-    "10.3 CSP": {},
-    "10.75 x 68": {},
-    "12.7 x 70 (500 Schüler)": {},
-    "12.7 x 108": {},
-    "17 Libra": {},
-    "17 Remington": {},
-    "17 Remington Fireball": {},
-    "204 Ruger": {},
-    "22 Palmisano & Pindel Cartridge-USA": {},
-    "22-250 Remington": {},
-    "220 Swift": {},
-    "222 Remington": {},
-    "222 Remington Magnum": {},
-    "223 Remington": {},
-    "223 Winchester Super Short Magnum": {},
-    "243 Winchester": {},
-    "243 Winchester Super Short Magnum": {},
-    "25 Remington": {},
-    "25 Winchester SSM": {},
-    "25-06 Remington": {},
-    "250 Savage": {},
-    "255 Giani Special": {},
-    "256 Magnum Gibbs": {},
-    "257 Roberts": {},
-    "260 Remington": {},
-    "264 Leroy Nitro Express": {},
-    "270 Winchester": {},
-    "270 Winchester Short Magnum": {},
-    "275 H.V. Rigby": {},
-    "277 Giani Special": {},
-    "280 Remington": {},
-    "280 Rimless Nitro Express Ross": {},
-    "284 Tony": {},
-    "284 Winchester": {},
-    "30 BR": {},
-    "30 Carbine": {},
-    "30 Court": {},
-    "30 Remington": {},
-    "30 TC": {},
-    "30-06 Ackley Improved": {},
-    "30-06 Court Cartry": {},
-    "30-06 Springfield": {},
-    "30-284 NOLASCO": {},
-    "30-284 Winchester": {},
-    "30-338 Prechtl Magnum": {},
-    "30-47 Giani Special": {},
-    "300 Advanced Armament Corporation Blackout": {},
-    "300 Blacktornado": {},
-    "300 Blaser Magnum": {},
-    "300 CR": {},
-    "300 Lapua Magnum": {},
-    "300 Norma Magnum": {},
-    "300 Pegasus": {},
-    "300 RCM": {},
-    "300 Remington Short Action Ultra Magnum": {},
-    "300 Remington Ultra Magnum": {},
-    "300 Savage": {},
-    "300 Winchester Short Magnum": {},
-    "308 EH": {},
-    "308 Match": {},
-    "308 Winchester": {},
-    "318 Rimless Nitro Express": {},
-    "32 Remington": {},
-    "325 Winchester Short Magnum": {},
-    "333 Rimless Nitro Express": {},
-    "338 Blaser Magnum": {},
-    "338 Federal": {},
-    "338 Lapua Magnum": {},
-    "338 Norma Magnum": {},
-    "338 RCM": {},
-    "338 Remington Ultra Magnum": {},
-    "338 Winchester Short Magnum": {},
-    "35 Remington": {},
-    "35 Whelen": {},
-    "350 Magnum Rigby": {},
-    "358 Winchester": {},
-    "375 Blaser Magnum": {},
-    "375 Chey Tac": {},
-    "375 Hölderlin": {},
-    "375 Remington Ultra Magnum": {},
-    "375 Ruger": {},
-    "376 Steyr": {},
-    "404 Rimless Nitro Express": {},
-    "408 Chey Tac": {},
-    "416 A-TEC": {},
-    "416 Barrett": {},
-    "416 Rigby": {},
-    "416 Ruger": {},
-    "416 Taylor": {},
-    "45 Blaser": {},
-    "450 Bushmaster": {},
-    "450 Rigby": {},
-    "460 Steyr": {},
-    "50 Browning": {},
-    "500 Jeffery": {},
-    "505 Magnum Gibbs": {},
-    "510 DTC": {},
-    "5.6 x 35 R": {},
-    "5.6 x 50 R Magnum": {},
-    "5.6 x 52 R": {},
-    "5.6 x 57 R": {},
-    "5.6 x 61 R Super Express Vom Hofe": {},
-    "5.6 x 70 R": {},
-    "6 x 50 R Scheiring": {},
-    "6 x 52 R BB2": {},
-    "6 x 52 R Bretschneider": {},
-    "6 x 62 R Freres": {},
-    "6 x 70 R": {},
-    "6.5 x 50 R": {},
-    "6.5 x 51 R (Arisaka)": {},
-    "6.5 x 52 R": {},
-    "6.5 x 52 R Keller & Simmann": {},
-    "6.5 x 57 R": {},
-    "6.5 x 58 R": {},
-    "6.5 x 65 R Rheinisch-Westfälischen Sprengstoff-Fabriken": {},
-    "6.5 x 68 R": {},
-    "6.5 x 70 R": {},
-    "7-30 Waters": {},
-    "7 x 50 R": {},
-    "7 x 57 R": {},
-    "7mm Magnum Flanged Holland & Holland": {},
-    "7 x 65 R": {},
-    "7 x 67 R Luyven": {},
-    "7 x 72 R": {},
-    "7 x 75 R Super Express Vom Hofe": {},
-    "7.62 x 53 R": {},
-    "7.62 x 54 R": {},
-    "8 x 50 R": {},
-    "8 x 51 R Lebel": {},
-    "8 x 56 R M30S": {},
-    "8 x 56 R M89 Portuguese Kropatschek": {},
-    "8 x 57 R 360": {},
-    "8 x 57 IR": {},
-    "8 x 57 IRS": {},
-    "8 x 58 R": {},
-    "8 x 60 R": {},
-    "8 x 60 RS": {},
-    "8 x 65 R": {},
-    "8 x 65 RS": {},
-    "8 x 72 R": {},
-    "8 x 75 RS": {},
-    "8mm – 348 Winchester": {},
-    "8.15 x 46 R": {},
-    "8.2 x 53 R": {},
-    "8.5 x 63 R": {},
-    "8.5 x 75 R Scheiring": {},
-    "9 x 53 R": {},
-    "9 x 57 R": {},
-    "9.3 x 53 R Finnish": {},
-    "9.3 x 72 R": {},
-    "9.3 x 74 R": {},
-    "10.3 x 60 R": {},
-    "11.15 x 60 R": {},
-    "17 Hornet": {},
-    "218 Bee": {},
-    "219 Zipper": {},
-    "22 Hornet": {},
-    "22 Savage": {},
-    "222 R Stief": {},
-    "225 Winchester": {},
-    "240 Flanged Nitro Express": {},
-    "25-20 Winchester": {},
-    "25-35 Winchester": {},
-    "256 Winchester Magnum": {},
-    "280 Flanged Nitro Express": {},
-    "297/230 Morris Long": {},
-    "297/230 Morris sh": {},
-    "30 R Blaser": {},
-    "30 Flanged Nitro Express Purdey": {},
-    "30 Super Flanged Holland & Holland": {},
-    "30-06 R Stief": {},
-    "30-30 Winchester": {},
-    "30-40 Krag": {},
-    "300/295 Rook Rifle": {},
-    "300 Sherwood": {},
-    "303 British": {},
-    "303 Savage": {},
-    "303 Sporting": {},
-    "307 Winchester": {},
-    "308 Marlin Express": {},
-    "310 Cadet Rifle": {},
-    "32 Winchester Self-loading": {},
-    "32 Winchester Special": {},
-    "32-20 Winchester": {},
-    "32-40 Winchester": {},
-    "33 Winchester": {},
-    "338 Marlin Express": {},
-    "348 Winchester": {},
-    "35 Winchester": {},
-    "35 Winchester Self-loading": {},
-    "350 No. 2 Rigby": {},
-    "351 Winchester Self-loading": {},
-    "356 Winchester": {},
-    "360 Nitro Express 21/4": {},
-    "369 Nitro Express Purdey": {},
-    "375 Flanged Nitro Express 21/2": {},
-    "375 Flanged Magnum Nitro Express": {},
-    "375 R Hölderlin": {},
-    "375 R Verney-Carron": {},
-    "375 Winchester": {},
-    "38-40 Winchester": {},
-    "38-55 Winchester": {},
-    "380 Long Rifle": {},
-    "40-60 Winchester": {},
-    "40-65 Winchester": {},
-    "40-82 Winchester": {},
-    "400 Purdey 3”": {},
-    "400/350 Nitro Express": {},
-    "401 Winchester Self-loading": {},
-    "405 Winchester": {},
-    "408 Winchester": {},
-    "44-40 Winchester": {},
-    "444 Marlin": {},
-    "45-60 Winchester": {},
-    "45-70 Elko Magnum": {},
-    "45-70 Government": {},
-    "45-75 Winchester": {},
-    "45-90 WM": {},
-    "45-110 Sharps 2\" 7/8": {},
-    "45-120 Sharps 3\" 1/4": {},
-    "450 Nitro Express 3\" 1/4": {},
-    "450 N° 2 Nitro Express 3\" 1/2 Eley": {},
-    "450/400 Nitro Express 3": {},
-    "450/400 Magnum Nitro Express 31/4": {},
-    "470 Nitro Express": {},
-    "475 N° 2 Nitro Express 31/2": {},
-    "475 N° 2 Nitro Express 3\" 1/2 Jeffery": {},
-    "50-70 Government": {},
-    "50-90 Sharps 2\" 1/2": {},
-    "50-95 Winchester": {},
-    "500 Nitro Express 3\"": {},
-    "500/416 Nitro Express 3\" 1/4": {},
-    "500/465 Nitro Express": {},
-    "56/50 Spencer": {},
-    "577/450 Sld. Martini–Henry": {},
-    "577 Nitro Express 3\"": {},
-    "577 Sld. Snider": {},
-    "600 Nitro Express": {},
-    "700 Holland & Holland Nitro Express": {},
-    "4 Bore Rifle": {},
-    "6.5mm Remington Magnum": {},
-    "7 x 61 Super": {},
-    "7mm Remington Magnum": {},
-    "7mm Rosè": {},
-    "7mm Shooting Times Westerner": {},
-    "7mm Weatherby Magnum": {},
-    "8mm Remington Magnum": {},
-    "11.5 x 51": {},
-    "224 Weatherby Magnum": {},
-    "240 Belted Rimless Nitro Express": {},
-    "240 Weatherby Magnum": {},
-    "244 Holland & Holland Magnum": {},
-    "257 Weatherby Magnum": {},
-    "264 Winchester Magnum": {},
-    "270 Weatherby Magnum": {},
-    "275 Belted Nitro Express": {},
-    "30 Super Belted Rimless Holland & Holland": {},
-    "30-378 Weatherby Magnum": {},
-    "300 Holland & Holland Magnum": {},
-    "300 Weatherby Magnum": {},
-    "300 Winchester Magnum": {},
-    "308 Norma Magnum": {},
-    "338 Winchester Magnum": {},
-    "338-378 Weatherby Mag": {},
-    "340 Weatherby Magnum": {},
-    "350 Remington Magnum": {},
-    "358 Norma Magnum": {},
-    "375 Holland & Holland Magnum": {},
-    "375 Weatherby Magnum": {},
-    "378 Weatherby Magnum": {},
-    "400 Holland & Holland Belted Magnum": {},
-    "416 Remington Magnum": {},
-    "416 Taylor Magnum": {},
-    "416 Weatherby Magnum": {},
-    "450 Marlin": {},
-    "458 Lott": {},
-    "458 Winchester Magnum": {},
-    "460 Weatherby Magnum": {},
-    "465 Holland & Holland Belted Magnum": {}
+  "10.3 CSP" : {
+    "name" : "10.3 CSP",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 72.7,
+      "coal_inch" : 2.86220627
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/10-3-csp-en.pdf" ],
+    "diameter_mm" : 10.54,
+    "diameter_inch" : 0.41496085399999993
+  },
+  "10.3 x 60 R" : {
+    "name" : "10.3 x 60 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.9,
+      "coal_inch" : 3.10630089
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page52.pdf" ],
+    "diameter_mm" : 10.54,
+    "diameter_inch" : 0.41496085399999993
+  },
+  "10.75 x 68" : {
+    "name" : "10.75 x 68",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 81.0,
+      "coal_inch" : 3.1889781
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page74.pdf" ],
+    "diameter_mm" : 10.78,
+    "diameter_inch" : 0.42440967799999996
+  },
+  "11.15 x 60 R" : {
+    "name" : "11.15 x 60 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.0,
+      "coal_inch" : 3.0708678
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page53.pdf" ],
+    "diameter_mm" : 11.4,
+    "diameter_inch" : 0.44881914
+  },
+  "11.5 x 51" : {
+    "name" : "11.5 x 51",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 62.0,
+      "coal_inch" : 2.4409462
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page7.pdf" ],
+    "diameter_mm" : 11.49,
+    "diameter_inch" : 0.452362449
+  },
+  "12.7 x 108" : {
+    "name" : "12.7 x 108",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 147.0,
+      "coal_inch" : 5.7874047
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/12-7-x-108-170419-en.pdf" ],
+    "diameter_mm" : 13.01,
+    "diameter_inch" : 0.512205001
+  },
+  "12.7 x 70 (500 Schüler)" : {
+    "name" : "12.7 x 70 (500 Schüler)",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 88.0,
+      "coal_inch" : 3.4645688
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page75.pdf" ],
+    "diameter_mm" : 12.96,
+    "diameter_inch" : 0.510236496
+  },
+  "17 Hornet" : {
+    "name" : "17 Hornet",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 43.69,
+      "coal_inch" : 1.7200796689999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/17-hornet-en.pdf" ],
+    "diameter_mm" : 4.38,
+    "diameter_inch" : 0.172441038
+  },
+  "17 Libra" : {
+    "name" : "17 Libra",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 41.0,
+      "coal_inch" : 1.6141740999999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page76.pdf" ],
+    "diameter_mm" : 4.28,
+    "diameter_inch" : 0.168504028
+  },
+  "17 Remington" : {
+    "name" : "17 Remington",
+    "names" : [ "17 Rem." ],
+    "specs" : {
+      "coal_mm" : 54.61,
+      "coal_inch" : 2.150001161
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page77.pdf" ],
+    "diameter_mm" : 4.38,
+    "diameter_inch" : 0.172441038
+  },
+  "17 Remington Fireball" : {
+    "name" : "17 Remington Fireball",
+    "names" : [ "17 Rem. Fireball" ],
+    "specs" : {
+      "coal_mm" : 46.48,
+      "coal_inch" : 1.8299222479999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/17-rem-fireball-en.pdf" ],
+    "diameter_mm" : 4.38,
+    "diameter_inch" : 0.172441038
+  },
+  "204 Ruger" : {
+    "name" : "204 Ruger",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 57.4,
+      "coal_inch" : 2.25984374
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page79.pdf" ],
+    "diameter_mm" : 5.19,
+    "diameter_inch" : 0.204330819
+  },
+  "215" : {
+    "name" : "215",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 58.0,
+      "coal_inch" : 2.2834658
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/215-en.pdf" ],
+    "diameter_mm" : 5.64,
+    "diameter_inch" : 0.22204736399999997
+  },
+  "218 Bee" : {
+    "name" : "218 Bee",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 42.67,
+      "coal_inch" : 1.679922167
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page54.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "219 Zipper" : {
+    "name" : "219 Zipper",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 57.4,
+      "coal_inch" : 2.25984374
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page55.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "22 Hornet" : {
+    "name" : "22 Hornet",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 43.76,
+      "coal_inch" : 1.7228355759999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page56.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "22 Palmisano & Pindel Cartridge-USA" : {
+    "name" : "22 Palmisano & Pindel Cartridge-USA",
+    "names" : [ "22 PPC-USA" ],
+    "specs" : {
+      "coal_mm" : 55.7,
+      "coal_inch" : 2.19291457
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page81.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "22 Savage" : {
+    "name" : "22 Savage",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 63.75,
+      "coal_inch" : 2.509843875
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page57.pdf" ],
+    "diameter_mm" : 5.79,
+    "diameter_inch" : 0.227952879
+  },
+  "22-250 Remington" : {
+    "name" : "22-250 Remington",
+    "names" : [ "22-250 Rem." ],
+    "specs" : {
+      "coal_mm" : 59.69,
+      "coal_inch" : 2.350001269
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page82.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "220 Swift" : {
+    "name" : "220 Swift",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 68.07,
+      "coal_inch" : 2.679922707
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page83.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "222 R Stief" : {
+    "name" : "222 R Stief",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 54.1,
+      "coal_inch" : 2.12992241
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/222-r-stief-en.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "222 Remington" : {
+    "name" : "222 Remington",
+    "names" : [ "222 Rem." ],
+    "specs" : {
+      "coal_mm" : 54.1,
+      "coal_inch" : 2.12992241
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page84.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "222 Remington Magnum" : {
+    "name" : "222 Remington Magnum",
+    "names" : [ "222 Rem.Mag." ],
+    "specs" : {
+      "coal_mm" : 57.91,
+      "coal_inch" : 2.2799224909999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page85.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "223 Remington" : {
+    "name" : "223 Remington",
+    "names" : [ "223 Rem." ],
+    "specs" : {
+      "coal_mm" : 57.4,
+      "coal_inch" : 2.25984374
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/223-rem-170406-en.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "223 Winchester Super Short Magnum" : {
+    "name" : "223 Winchester Super Short Magnum",
+    "names" : [ "223 Win. SS Mag." ],
+    "specs" : {
+      "coal_mm" : 59.94,
+      "coal_inch" : 2.3598437939999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page87.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "224 Weatherby Magnum" : {
+    "name" : "224 Weatherby Magnum",
+    "names" : [ "224 Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 59.18,
+      "coal_inch" : 2.329922518
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page8.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "225 Winchester" : {
+    "name" : "225 Winchester",
+    "names" : [ "225 Win." ],
+    "specs" : {
+      "coal_mm" : 63.5,
+      "coal_inch" : 2.50000135
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/225-win-en.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "240 Belted Rimless Nitro Express" : {
+    "name" : "240 Belted Rimless Nitro Express",
+    "names" : [ "240 Belt. Riml. N.E." ],
+    "specs" : {
+      "coal_mm" : 82.55,
+      "coal_inch" : 3.2500017549999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page9.pdf" ],
+    "diameter_mm" : 6.22,
+    "diameter_inch" : 0.24488202199999998
+  },
+  "240 Flanged Nitro Express" : {
+    "name" : "240 Flanged Nitro Express",
+    "names" : [ "240 Fl. N.E." ],
+    "specs" : {
+      "coal_mm" : 82.55,
+      "coal_inch" : 3.2500017549999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page59.pdf" ],
+    "diameter_mm" : 6.22,
+    "diameter_inch" : 0.24488202199999998
+  },
+  "240 Weatherby Magnum" : {
+    "name" : "240 Weatherby Magnum",
+    "names" : [ "240 Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 78.74,
+      "coal_inch" : 3.1000016739999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page10.pdf" ],
+    "diameter_mm" : 6.18,
+    "diameter_inch" : 0.24330721799999996
+  },
+  "243 Winchester" : {
+    "name" : "243 Winchester",
+    "names" : [ "243 Win." ],
+    "specs" : {
+      "coal_mm" : 68.83,
+      "coal_inch" : 2.709843983
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page88.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "243 Winchester Super Short Magnum" : {
+    "name" : "243 Winchester Super Short Magnum",
+    "names" : [ "243 Win. SS Mag." ],
+    "specs" : {
+      "coal_mm" : 59.94,
+      "coal_inch" : 2.3598437939999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page89.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "244 Holland & Holland Magnum" : {
+    "name" : "244 Holland & Holland Magnum",
+    "names" : [ "244 H&H Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page11.pdf" ],
+    "diameter_mm" : 6.22,
+    "diameter_inch" : 0.24488202199999998
+  },
+  "25 Remington" : {
+    "name" : "25 Remington",
+    "names" : [ "25 Rem." ],
+    "specs" : {
+      "coal_mm" : 64.14,
+      "coal_inch" : 2.525198214
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page90.pdf" ],
+    "diameter_mm" : 6.58,
+    "diameter_inch" : 0.259055258
+  },
+  "25 Winchester SSM" : {
+    "name" : "25 Winchester SSM",
+    "names" : [ "25 Win. SSM" ],
+    "specs" : {
+      "coal_mm" : 59.94,
+      "coal_inch" : 2.3598437939999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/25-win-super-short-mag-en.pdf" ],
+    "diameter_mm" : 6.54,
+    "diameter_inch" : 0.25748045399999997
+  },
+  "25-06 Remington" : {
+    "name" : "25-06 Remington",
+    "names" : [ "25-06 Rem." ],
+    "specs" : {
+      "coal_mm" : 82.55,
+      "coal_inch" : 3.2500017549999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page92.pdf" ],
+    "diameter_mm" : 6.54,
+    "diameter_inch" : 0.25748045399999997
+  },
+  "25-20 Winchester" : {
+    "name" : "25-20 Winchester",
+    "names" : [ "25-20 Win." ],
+    "specs" : {
+      "coal_mm" : 40.44,
+      "coal_inch" : 1.5921268439999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page60.pdf" ],
+    "diameter_mm" : 6.55,
+    "diameter_inch" : 0.257874155
+  },
+  "25-35 Winchester" : {
+    "name" : "25-35 Winchester",
+    "names" : [ "25-35 Win." ],
+    "specs" : {
+      "coal_mm" : 64.77,
+      "coal_inch" : 2.5500013769999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page61.pdf" ],
+    "diameter_mm" : 6.55,
+    "diameter_inch" : 0.257874155
+  },
+  "250 Savage" : {
+    "name" : "250 Savage",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 63.88,
+      "coal_inch" : 2.514961988
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page93.pdf" ],
+    "diameter_mm" : 6.55,
+    "diameter_inch" : 0.257874155
+  },
+  "255 Giani Special" : {
+    "name" : "255 Giani Special",
+    "names" : [ "255 GS" ],
+    "specs" : {
+      "coal_mm" : 72.5,
+      "coal_inch" : 2.8543322499999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page94.pdf" ],
+    "diameter_mm" : 6.54,
+    "diameter_inch" : 0.25748045399999997
+  },
+  "256 Magnum Gibbs" : {
+    "name" : "256 Magnum Gibbs",
+    "names" : [ "256 Mag. Gibbs" ],
+    "specs" : {
+      "coal_mm" : 77.47,
+      "coal_inch" : 3.0500016469999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page95.pdf" ],
+    "diameter_mm" : 6.73,
+    "diameter_inch" : 0.264960773
+  },
+  "256 Winchester Magnum" : {
+    "name" : "256 Winchester Magnum",
+    "names" : [ "256 Win. Mag." ],
+    "specs" : {
+      "coal_mm" : 40.39,
+      "coal_inch" : 1.590158339
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/256-win-mag-en.pdf" ],
+    "diameter_mm" : 6.53,
+    "diameter_inch" : 0.257086753
+  },
+  "257 Roberts" : {
+    "name" : "257 Roberts",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 70.49,
+      "coal_inch" : 2.7751983489999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page96.pdf" ],
+    "diameter_mm" : 6.55,
+    "diameter_inch" : 0.257874155
+  },
+  "257 Weatherby Magnum" : {
+    "name" : "257 Weatherby Magnum",
+    "names" : [ "257 Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 80.52,
+      "coal_inch" : 3.1700804519999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page12.pdf" ],
+    "diameter_mm" : 6.54,
+    "diameter_inch" : 0.25748045399999997
+  },
+  "260 Remington" : {
+    "name" : "260 Remington",
+    "names" : [ "260 Rem." ],
+    "specs" : {
+      "coal_mm" : 71.12,
+      "coal_inch" : 2.800001512
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page97.pdf" ],
+    "diameter_mm" : 6.72,
+    "diameter_inch" : 0.26456707199999996
+  },
+  "264 Leroy Nitro Express" : {
+    "name" : "264 Leroy Nitro Express",
+    "names" : [ "264 Leroy N.E." ],
+    "specs" : {
+      "coal_mm" : 65.0,
+      "coal_inch" : 2.5590565
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page98.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "264 Winchester Magnum" : {
+    "name" : "264 Winchester Magnum",
+    "names" : [ "264 Win. Mag." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page13.pdf" ],
+    "diameter_mm" : 6.73,
+    "diameter_inch" : 0.264960773
+  },
+  "270 Weatherby Magnum" : {
+    "name" : "270 Weatherby Magnum",
+    "names" : [ "270 Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 83.69,
+      "coal_inch" : 3.294883669
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page14.pdf" ],
+    "diameter_mm" : 7.04,
+    "diameter_inch" : 0.277165504
+  },
+  "270 Winchester" : {
+    "name" : "270 Winchester",
+    "names" : [ "270 Win." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page99.pdf" ],
+    "diameter_mm" : 7.06,
+    "diameter_inch" : 0.27795290599999994
+  },
+  "270 Winchester Short Magnum" : {
+    "name" : "270 Winchester Short Magnum",
+    "names" : [ "270 Win. Short Mag." ],
+    "specs" : {
+      "coal_mm" : 72.64,
+      "coal_inch" : 2.859844064
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page100.pdf" ],
+    "diameter_mm" : 7.06,
+    "diameter_inch" : 0.27795290599999994
+  },
+  "275 Belted Nitro Express" : {
+    "name" : "275 Belted Nitro Express",
+    "names" : [ "275 Belt. N.E." ],
+    "specs" : {
+      "coal_mm" : 87.12,
+      "coal_inch" : 3.429923112
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page15.pdf" ],
+    "diameter_mm" : 7.29,
+    "diameter_inch" : 0.287008029
+  },
+  "275 H.V. Rigby" : {
+    "name" : "275 H.V. Rigby",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 77.98,
+      "coal_inch" : 3.070080398
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page101.pdf" ],
+    "diameter_mm" : 7.21,
+    "diameter_inch" : 0.28385842099999997
+  },
+  "277 Giani Special" : {
+    "name" : "277 Giani Special",
+    "names" : [ "277 GS" ],
+    "specs" : {
+      "coal_mm" : 87.0,
+      "coal_inch" : 3.4251986999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/277-gs-en.pdf" ],
+    "diameter_mm" : 7.06,
+    "diameter_inch" : 0.27795290599999994
+  },
+  "280 Flanged Nitro Express" : {
+    "name" : "280 Flanged Nitro Express",
+    "names" : [ "280 Fl. N.E." ],
+    "specs" : {
+      "coal_mm" : 87.88,
+      "coal_inch" : 3.4598443879999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page63.pdf" ],
+    "diameter_mm" : 7.29,
+    "diameter_inch" : 0.287008029
+  },
+  "280 Remington" : {
+    "name" : "280 Remington",
+    "names" : [ "280 Rem." ],
+    "specs" : {
+      "coal_mm" : 84.58,
+      "coal_inch" : 3.329923058
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page103.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "280 Rimless Nitro Express Ross" : {
+    "name" : "280 Rimless Nitro Express Ross",
+    "names" : [ "280 Riml. N.E. Ross" ],
+    "specs" : {
+      "coal_mm" : 87.88,
+      "coal_inch" : 3.4598443879999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page104.pdf" ],
+    "diameter_mm" : 7.29,
+    "diameter_inch" : 0.287008029
+  },
+  "284 Tony" : {
+    "name" : "284 Tony",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.0,
+      "coal_inch" : 3.0708678
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/284-tony-en.pdf" ],
+    "diameter_mm" : 7.21,
+    "diameter_inch" : 0.28385842099999997
+  },
+  "284 Winchester" : {
+    "name" : "284 Winchester",
+    "names" : [ "284 Win." ],
+    "specs" : {
+      "coal_mm" : 71.12,
+      "coal_inch" : 2.800001512
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page105.pdf" ],
+    "diameter_mm" : 7.21,
+    "diameter_inch" : 0.28385842099999997
+  },
+  "297/230 Morris Long" : {
+    "name" : "297/230 Morris Long",
+    "names" : [ "297/230 Morris lg" ],
+    "specs" : {
+      "coal_mm" : 27.43,
+      "coal_inch" : 1.079921843
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page64.pdf" ],
+    "diameter_mm" : 5.71,
+    "diameter_inch" : 0.224803271
+  },
+  "297/230 Morris sh" : {
+    "name" : "297/230 Morris sh",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 22.61,
+      "coal_inch" : 0.8901579609999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page65.pdf" ],
+    "diameter_mm" : 5.71,
+    "diameter_inch" : 0.224803271
+  },
+  "30 BR" : {
+    "name" : "30 BR",
+    "names" : [ "30 Bench Rest" ],
+    "specs" : {
+      "coal_mm" : 58.0,
+      "coal_inch" : 2.2834658
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/30-br-en.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "30 Carbine" : {
+    "name" : "30 Carbine",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 42.67,
+      "coal_inch" : 1.679922167
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page106.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30 Court" : {
+    "name" : "30 Court",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 41.35,
+      "coal_inch" : 1.627953635
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page107.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30 Flanged Nitro Express Purdey" : {
+    "name" : "30 Flanged Nitro Express Purdey",
+    "names" : [ "30 Fl. N.E. Purdey" ],
+    "specs" : {
+      "coal_mm" : 75.69,
+      "coal_inch" : 2.9799228689999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/30-fi-ne-purdey-en.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "30 R Blaser" : {
+    "name" : "30 R Blaser",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 95.0,
+      "coal_inch" : 3.7401595
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page66.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30 Remington" : {
+    "name" : "30 Remington",
+    "names" : [ "30 Rem." ],
+    "specs" : {
+      "coal_mm" : 64.14,
+      "coal_inch" : 2.525198214
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page108.pdf" ],
+    "diameter_mm" : 7.8,
+    "diameter_inch" : 0.30708678
+  },
+  "30 Super Belted Rimless Holland & Holland" : {
+    "name" : "30 Super Belted Rimless Holland & Holland",
+    "names" : [ "30 Super Bl Riml. H&H" ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page16.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "30 Super Flanged Holland & Holland" : {
+    "name" : "30 Super Flanged Holland & Holland",
+    "names" : [ "300 Fl. N.E.", "30 Super Fl. H&H" ],
+    "specs" : {
+      "coal_mm" : 93.73,
+      "coal_inch" : 3.690159473
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/30-super-fi-h-h-en.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "30 TC" : {
+    "name" : "30 TC",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 67.56,
+      "coal_inch" : 2.659843956
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page109.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-06 Ackley Improved" : {
+    "name" : "30-06 Ackley Improved",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/30-06-ackley-improved-en.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-06 Court Cartry" : {
+    "name" : "30-06 Court Cartry",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.3,
+      "coal_inch" : 3.2401592299999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page110.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-06 R Stief" : {
+    "name" : "30-06 R Stief",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page69.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-06 Springfield" : {
+    "name" : "30-06 Springfield",
+    "names" : [ "30-06", "7,62 x 63", "30-06 Spring." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page111.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-284 NOLASCO" : {
+    "name" : "30-284 NOLASCO",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 76.0,
+      "coal_inch" : 2.9921276
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page112.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-284 Winchester" : {
+    "name" : "30-284 Winchester",
+    "names" : [ "30-284 Win." ],
+    "specs" : {
+      "coal_mm" : 72.0,
+      "coal_inch" : 2.8346472
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page113.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-30 Winchester" : {
+    "name" : "30-30 Winchester",
+    "names" : [ "30-30 Win." ],
+    "specs" : {
+      "coal_mm" : 64.77,
+      "coal_inch" : 2.5500013769999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page70.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-338 Prechtl Magnum" : {
+    "name" : "30-338 Prechtl Magnum",
+    "names" : [ "30-338 Prechtl Mag." ],
+    "specs" : {
+      "coal_mm" : 93.2,
+      "coal_inch" : 3.66929332
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/30-338-prechtl-magnum-170310-en.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-378 Weatherby Magnum" : {
+    "name" : "30-378 Weatherby Magnum",
+    "names" : [ "30-378 Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 95.25,
+      "coal_inch" : 3.7500020249999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page17.pdf" ],
+    "diameter_mm" : 7.83,
+    "diameter_inch" : 0.30826788299999996
+  },
+  "30-40 Krag" : {
+    "name" : "30-40 Krag",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.46,
+      "coal_inch" : 3.088978046
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/30-40-krag-en.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "30-47 Giani Special" : {
+    "name" : "30-47 Giani Special",
+    "names" : [ "30-47 GS" ],
+    "specs" : {
+      "coal_mm" : 66.6,
+      "coal_inch" : 2.6220486599999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/30-47-gs-en.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "300 Advanced Armament Corporation Blackout" : {
+    "name" : "300 Advanced Armament Corporation Blackout",
+    "names" : [ "300 Whisper", "300 BLK", "7,62 x 35", "300 AAC Blackout" ],
+    "specs" : {
+      "coal_mm" : 57.4,
+      "coal_inch" : 2.25984374
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-aac-blacout-170307-en.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "300 Blacktornado" : {
+    "name" : "300 Blacktornado",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.0,
+      "coal_inch" : 3.3070884
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-blacktornado-en.pdf" ],
+    "diameter_mm" : 7.83,
+    "diameter_inch" : 0.30826788299999996
+  },
+  "300 Blaser Magnum" : {
+    "name" : "300 Blaser Magnum",
+    "names" : [ "300 Blaser Mag." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page114.pdf" ],
+    "diameter_mm" : 7.83,
+    "diameter_inch" : 0.30826788299999996
+  },
+  "300 CR" : {
+    "name" : "300 CR",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 71.0,
+      "coal_inch" : 2.7952771
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page115.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "300 Holland & Holland Magnum" : {
+    "name" : "300 Holland & Holland Magnum",
+    "names" : [ "30 Super Belt. Riml. H&H", "300 H&H Belt. Riml. N.E.", "300 H&H Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/300-h-h-mag-en.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "300 Lapua Magnum" : {
+    "name" : "300 Lapua Magnum",
+    "names" : [ "300 Lapua Mag." ],
+    "specs" : {
+      "coal_mm" : 94.5,
+      "coal_inch" : 3.7204744499999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page116.pdf" ],
+    "diameter_mm" : 7.87,
+    "diameter_inch" : 0.309842687
+  },
+  "300 Norma Magnum" : {
+    "name" : "300 Norma Magnum",
+    "names" : [ "300 Norma Mag" ],
+    "specs" : {
+      "coal_mm" : 93.5,
+      "coal_inch" : 3.68110435
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-norma-mag-en.pdf" ],
+    "diameter_mm" : 7.83,
+    "diameter_inch" : 0.30826788299999996
+  },
+  "300 Pegasus" : {
+    "name" : "300 Pegasus",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 95.25,
+      "coal_inch" : 3.7500020249999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-pegasus-en.pdf" ],
+    "diameter_mm" : 7.82,
+    "diameter_inch" : 0.307874182
+  },
+  "300 RCM" : {
+    "name" : "300 RCM",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 72.14,
+      "coal_inch" : 2.8401590139999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-rcm-en.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "300 Remington Short Action Ultra Magnum" : {
+    "name" : "300 Remington Short Action Ultra Magnum",
+    "names" : [ "300 Rem. SA Ultra Mag." ],
+    "specs" : {
+      "coal_mm" : 71.76,
+      "coal_inch" : 2.825198376
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page118.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "300 Remington Ultra Magnum" : {
+    "name" : "300 Remington Ultra Magnum",
+    "names" : [ "300 Rem. Ultra Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page119.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "300 Savage" : {
+    "name" : "300 Savage",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 66.04,
+      "coal_inch" : 2.600001404
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page120.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "300 Sherwood" : {
+    "name" : "300 Sherwood",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 51.82,
+      "coal_inch" : 2.040158582
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page73.pdf" ],
+    "diameter_mm" : 7.62,
+    "diameter_inch" : 0.300000162
+  },
+  "300 Weatherby Magnum" : {
+    "name" : "300 Weatherby Magnum",
+    "names" : [ "300 Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 90.42,
+      "coal_inch" : 3.5598444419999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page19.pdf" ],
+    "diameter_mm" : 7.83,
+    "diameter_inch" : 0.30826788299999996
+  },
+  "300 Winchester Magnum" : {
+    "name" : "300 Winchester Magnum",
+    "names" : [ "300 Win. Mag." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page20.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "300 Winchester Short Magnum" : {
+    "name" : "300 Winchester Short Magnum",
+    "names" : [ "300 Win. Short Mag." ],
+    "specs" : {
+      "coal_mm" : 72.64,
+      "coal_inch" : 2.859844064
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page122.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "300/295 Rook Rifle" : {
+    "name" : "300/295 Rook Rifle",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 36.83,
+      "coal_inch" : 1.450000783
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/300-295-rook-rifle-en.pdf" ],
+    "diameter_mm" : 7.65,
+    "diameter_inch" : 0.301181265
+  },
+  "303 British" : {
+    "name" : "303 British",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.11,
+      "coal_inch" : 3.075198511
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page74.pdf" ],
+    "diameter_mm" : 7.92,
+    "diameter_inch" : 0.31181119199999996
+  },
+  "303 Savage" : {
+    "name" : "303 Savage",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 64.01,
+      "coal_inch" : 2.520080101
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/303-savage-en.pdf" ],
+    "diameter_mm" : 7.9,
+    "diameter_inch" : 0.31102379
+  },
+  "303 Sporting" : {
+    "name" : "303 Sporting",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 74.49,
+      "coal_inch" : 2.9326787489999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page76.pdf" ],
+    "diameter_mm" : 7.92,
+    "diameter_inch" : 0.31181119199999996
+  },
+  "307 Winchester" : {
+    "name" : "307 Winchester",
+    "names" : [ "307 Win." ],
+    "specs" : {
+      "coal_mm" : 65.02,
+      "coal_inch" : 2.559843902
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/307-win-en.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "308 EH" : {
+    "name" : "308 EH",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 57.5,
+      "coal_inch" : 2.26378075
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page123.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "308 Marlin Express" : {
+    "name" : "308 Marlin Express",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 66.04,
+      "coal_inch" : 2.600001404
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/308-marlin-express-en.pdf" ],
+    "diameter_mm" : 7.84,
+    "diameter_inch" : 0.308661584
+  },
+  "308 Match" : {
+    "name" : "308 Match",
+    "names" : [ "308 GAC" ],
+    "specs" : {
+      "coal_mm" : 71.12,
+      "coal_inch" : 2.800001512
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/308-match-en.pdf" ],
+    "diameter_mm" : 7.84,
+    "diameter_inch" : 0.308661584
+  },
+  "308 Norma Magnum" : {
+    "name" : "308 Norma Magnum",
+    "names" : [ "308 Norma Mag." ],
+    "specs" : {
+      "coal_mm" : 85.0,
+      "coal_inch" : 3.3464585
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/308-norma-mag-en.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "308 Winchester" : {
+    "name" : "308 Winchester",
+    "names" : [ "7,62 x 51", "308 Winchester", "308 Win." ],
+    "specs" : {
+      "coal_mm" : 71.12,
+      "coal_inch" : 2.800001512
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page125.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "310 Cadet Rifle" : {
+    "name" : "310 Cadet Rifle",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 40.64,
+      "coal_inch" : 1.6000008639999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page78.pdf" ],
+    "diameter_mm" : 8.2,
+    "diameter_inch" : 0.32283481999999997
+  },
+  "318 Rimless Nitro Express" : {
+    "name" : "318 Rimless Nitro Express",
+    "names" : [ "318 Westley Richards", "318 Riml. N.E." ],
+    "specs" : {
+      "coal_mm" : 89.66,
+      "coal_inch" : 3.5299231659999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page126.pdf" ],
+    "diameter_mm" : 8.38,
+    "diameter_inch" : 0.329921438
+  },
+  "32 Remington" : {
+    "name" : "32 Remington",
+    "names" : [ "32 Rem." ],
+    "specs" : {
+      "coal_mm" : 64.14,
+      "coal_inch" : 2.525198214
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page127.pdf" ],
+    "diameter_mm" : 8.15,
+    "diameter_inch" : 0.320866315
+  },
+  "32 Winchester Self-loading" : {
+    "name" : "32 Winchester Self-loading",
+    "names" : [ "32 Win. SL" ],
+    "specs" : {
+      "coal_mm" : 47.75,
+      "coal_inch" : 1.879922275
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page79.pdf" ],
+    "diameter_mm" : 8.18,
+    "diameter_inch" : 0.322047418
+  },
+  "32 Winchester Special" : {
+    "name" : "32 Winchester Special",
+    "names" : [ "32 Win. Spec." ],
+    "specs" : {
+      "coal_mm" : 65.15,
+      "coal_inch" : 2.5649620150000003
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page80.pdf" ],
+    "diameter_mm" : 8.18,
+    "diameter_inch" : 0.322047418
+  },
+  "32-20 Winchester" : {
+    "name" : "32-20 Winchester",
+    "names" : [ "32-20 Win." ],
+    "specs" : {
+      "coal_mm" : 40.44,
+      "coal_inch" : 1.5921268439999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page81.pdf" ],
+    "diameter_mm" : 7.94,
+    "diameter_inch" : 0.312598594
+  },
+  "32-40 Winchester" : {
+    "name" : "32-40 Winchester",
+    "names" : [ "32-40 Win." ],
+    "specs" : {
+      "coal_mm" : 63.5,
+      "coal_inch" : 2.50000135
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page82.pdf" ],
+    "diameter_mm" : 8.15,
+    "diameter_inch" : 0.320866315
+  },
+  "325 Winchester Short Magnum" : {
+    "name" : "325 Winchester Short Magnum",
+    "names" : [ "325 WSM" ],
+    "specs" : {
+      "coal_mm" : 72.64,
+      "coal_inch" : 2.859844064
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page128.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "33 Winchester" : {
+    "name" : "33 Winchester",
+    "names" : [ "33 Win." ],
+    "specs" : {
+      "coal_mm" : 70.99,
+      "coal_inch" : 2.7948833989999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page83.pdf" ],
+    "diameter_mm" : 8.6,
+    "diameter_inch" : 0.33858286
+  },
+  "333 Rimless Nitro Express" : {
+    "name" : "333 Rimless Nitro Express",
+    "names" : [ "333 Riml. N.E." ],
+    "specs" : {
+      "coal_mm" : 88.9,
+      "coal_inch" : 3.50000189
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page129.pdf" ],
+    "diameter_mm" : 8.46,
+    "diameter_inch" : 0.33307104600000004
+  },
+  "338 Blaser Magnum" : {
+    "name" : "338 Blaser Magnum",
+    "names" : [ "338 Blaser Mag." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page130.pdf" ],
+    "diameter_mm" : 8.59,
+    "diameter_inch" : 0.33818915899999996
+  },
+  "338 Federal" : {
+    "name" : "338 Federal",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 71.63,
+      "coal_inch" : 2.8200802629999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/338-federal-en.pdf" ],
+    "diameter_mm" : 8.61,
+    "diameter_inch" : 0.33897656099999995
+  },
+  "338 Lapua Magnum" : {
+    "name" : "338 Lapua Magnum",
+    "names" : [ "8,6 (mm) x 70", "338 Lapua Mag." ],
+    "specs" : {
+      "coal_mm" : 93.5,
+      "coal_inch" : 3.68110435
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/338-lapua-mag-en.pdf" ],
+    "diameter_mm" : 8.61,
+    "diameter_inch" : 0.33897656099999995
+  },
+  "338 Marlin Express" : {
+    "name" : "338 Marlin Express",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 62.23,
+      "coal_inch" : 2.450001323
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page84.pdf" ],
+    "diameter_mm" : 8.6,
+    "diameter_inch" : 0.33858286
+  },
+  "338 Norma Magnum" : {
+    "name" : "338 Norma Magnum",
+    "names" : [ "338 Norma Mag." ],
+    "specs" : {
+      "coal_mm" : 93.5,
+      "coal_inch" : 3.68110435
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page133.pdf" ],
+    "diameter_mm" : 8.6,
+    "diameter_inch" : 0.33858286
+  },
+  "338 RCM" : {
+    "name" : "338 RCM",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 72.14,
+      "coal_inch" : 2.8401590139999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/338-rcm-en.pdf" ],
+    "diameter_mm" : 8.61,
+    "diameter_inch" : 0.33897656099999995
+  },
+  "338 Remington Ultra Magnum" : {
+    "name" : "338 Remington Ultra Magnum",
+    "names" : [ "338 Rem. Ultra Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page134.pdf" ],
+    "diameter_mm" : 8.6,
+    "diameter_inch" : 0.33858286
+  },
+  "338 Winchester Magnum" : {
+    "name" : "338 Winchester Magnum",
+    "names" : [ "338 Win. Mag." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page22.pdf" ],
+    "diameter_mm" : 8.61,
+    "diameter_inch" : 0.33897656099999995
+  },
+  "338 Winchester Short Magnum" : {
+    "name" : "338 Winchester Short Magnum",
+    "names" : [ "338 Win. Short Mag." ],
+    "specs" : {
+      "coal_mm" : 69.78,
+      "coal_inch" : 2.747245578
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page135.pdf" ],
+    "diameter_mm" : 8.69,
+    "diameter_inch" : 0.342126169
+  },
+  "338-378 Weatherby Mag" : {
+    "name" : "338-378 Weatherby Mag",
+    "names" : [ "338-378 Weath. Mag" ],
+    "specs" : {
+      "coal_mm" : 95.58,
+      "coal_inch" : 3.7629941579999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page23.pdf" ],
+    "diameter_mm" : 8.6,
+    "diameter_inch" : 0.33858286
+  },
+  "340 Weatherby Magnum" : {
+    "name" : "340 Weatherby Magnum",
+    "names" : [ "340 Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 93.35,
+      "coal_inch" : 3.6751988349999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page24.pdf" ],
+    "diameter_mm" : 8.59,
+    "diameter_inch" : 0.33818915899999996
+  },
+  "348 Winchester" : {
+    "name" : "348 Winchester",
+    "names" : [ "348 Win." ],
+    "specs" : {
+      "coal_mm" : 70.99,
+      "coal_inch" : 2.7948833989999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page85.pdf" ],
+    "diameter_mm" : 8.88,
+    "diameter_inch" : 0.349606488
+  },
+  "35 Remington" : {
+    "name" : "35 Remington",
+    "names" : [ "35 Rem." ],
+    "specs" : {
+      "coal_mm" : 64.14,
+      "coal_inch" : 2.525198214
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page136.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "35 Whelen" : {
+    "name" : "35 Whelen",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page137.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "35 Winchester" : {
+    "name" : "35 Winchester",
+    "names" : [ "35 Win." ],
+    "specs" : {
+      "coal_mm" : 80.65,
+      "coal_inch" : 3.175198565
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page86.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "35 Winchester Self-loading" : {
+    "name" : "35 Winchester Self-loading",
+    "names" : [ "35 Win. SL" ],
+    "specs" : {
+      "coal_mm" : 41.91,
+      "coal_inch" : 1.6500008909999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page87.pdf" ],
+    "diameter_mm" : 8.95,
+    "diameter_inch" : 0.35236239499999994
+  },
+  "350 Magnum Rigby" : {
+    "name" : "350 Magnum Rigby",
+    "names" : [ "350 Mag. Rigby" ],
+    "specs" : {
+      "coal_mm" : 90.8,
+      "coal_inch" : 3.5748050799999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page138.pdf" ],
+    "diameter_mm" : 9.07,
+    "diameter_inch" : 0.357086807
+  },
+  "350 No. 2 Rigby" : {
+    "name" : "350 No. 2 Rigby",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 93.73,
+      "coal_inch" : 3.690159473
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page88.pdf" ],
+    "diameter_mm" : 9.04,
+    "diameter_inch" : 0.35590570399999993
+  },
+  "350 Remington Magnum" : {
+    "name" : "350 Remington Magnum",
+    "names" : [ "350 Rem.Mag." ],
+    "specs" : {
+      "coal_mm" : 71.12,
+      "coal_inch" : 2.800001512
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page25.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "351 Winchester Self-loading" : {
+    "name" : "351 Winchester Self-loading",
+    "names" : [ "351 Win. SL" ],
+    "specs" : {
+      "coal_mm" : 48.26,
+      "coal_inch" : 1.9000010259999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/351-win-sl-en.pdf" ],
+    "diameter_mm" : 8.94,
+    "diameter_inch" : 0.35196869399999997
+  },
+  "356 Winchester" : {
+    "name" : "356 Winchester",
+    "names" : [ "356 Win." ],
+    "specs" : {
+      "coal_mm" : 65.02,
+      "coal_inch" : 2.559843902
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/356-win-en.pdf" ],
+    "diameter_mm" : 9.11,
+    "diameter_inch" : 0.35866161099999994
+  },
+  "358 Norma Magnum" : {
+    "name" : "358 Norma Magnum",
+    "names" : [ "358 Norma Mag." ],
+    "specs" : {
+      "coal_mm" : 85.0,
+      "coal_inch" : 3.3464585
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page26.pdf" ],
+    "diameter_mm" : 9.12,
+    "diameter_inch" : 0.35905531199999996
+  },
+  "358 Winchester" : {
+    "name" : "358 Winchester",
+    "names" : [ "358 Win." ],
+    "specs" : {
+      "coal_mm" : 70.61,
+      "coal_inch" : 2.779922761
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page139.pdf" ],
+    "diameter_mm" : 9.11,
+    "diameter_inch" : 0.35866161099999994
+  },
+  "360 Nitro Express 21/4" : {
+    "name" : "360 Nitro Express 21/4",
+    "names" : [ "360 N.E. 21/4" ],
+    "specs" : {
+      "coal_mm" : 76.2,
+      "coal_inch" : 3.00000162
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page91.pdf" ],
+    "diameter_mm" : 9.32,
+    "diameter_inch" : 0.366929332
+  },
+  "369 Nitro Express Purdey" : {
+    "name" : "369 Nitro Express Purdey",
+    "names" : [ "369 N.E. Purdey" ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page92.pdf" ],
+    "diameter_mm" : 9.52,
+    "diameter_inch" : 0.374803352
+  },
+  "375 Blaser Magnum" : {
+    "name" : "375 Blaser Magnum",
+    "names" : [ "375 Blaser Mag." ],
+    "specs" : {
+      "coal_mm" : 92.0,
+      "coal_inch" : 3.6220491999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page140.pdf" ],
+    "diameter_mm" : 9.53,
+    "diameter_inch" : 0.37519705299999995
+  },
+  "375 Chey Tac" : {
+    "name" : "375 Chey Tac",
+    "names" : [ "9,5 x 77" ],
+    "specs" : {
+      "coal_mm" : 113.4,
+      "coal_inch" : 4.46456934
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/375-chey-tac-170627-en.pdf" ],
+    "diameter_mm" : 9.52,
+    "diameter_inch" : 0.374803352
+  },
+  "375 Flanged Magnum Nitro Express" : {
+    "name" : "375 Flanged Magnum Nitro Express",
+    "names" : [ "375 H&H Fl. Mag. N.E.", "375 Fl. Mag. N.E." ],
+    "specs" : {
+      "coal_mm" : 96.52,
+      "coal_inch" : 3.8000020519999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/375-fi-mag-ne-en.pdf" ],
+    "diameter_mm" : 9.52,
+    "diameter_inch" : 0.374803352
+  },
+  "375 Flanged Nitro Express 21/2" : {
+    "name" : "375 Flanged Nitro Express 21/2",
+    "names" : [ "375 Fl. N.E. 21/2" ],
+    "specs" : {
+      "coal_mm" : 82.55,
+      "coal_inch" : 3.2500017549999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page93.pdf" ],
+    "diameter_mm" : 9.52,
+    "diameter_inch" : 0.374803352
+  },
+  "375 Holland & Holland Magnum" : {
+    "name" : "375 Holland & Holland Magnum",
+    "names" : [ "375 H&H Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page27.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  },
+  "375 Hölderlin" : {
+    "name" : "375 Hölderlin",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.0,
+      "coal_inch" : 3.4251986999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page141.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  },
+  "375 R Hölderlin" : {
+    "name" : "375 R Hölderlin",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.0,
+      "coal_inch" : 3.4251986999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page95.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  },
+  "375 R Verney-Carron" : {
+    "name" : "375 R Verney-Carron",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 92.25,
+      "coal_inch" : 3.631891725
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page96.pdf" ],
+    "diameter_mm" : 9.53,
+    "diameter_inch" : 0.37519705299999995
+  },
+  "375 Remington Ultra Magnum" : {
+    "name" : "375 Remington Ultra Magnum",
+    "names" : [ "375 Rem. Ultra Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page142.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  },
+  "375 Ruger" : {
+    "name" : "375 Ruger",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page143.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  },
+  "375 Weatherby Magnum" : {
+    "name" : "375 Weatherby Magnum",
+    "names" : [ "375 Weath.Mag." ],
+    "specs" : {
+      "coal_mm" : 90.5,
+      "coal_inch" : 3.56299405
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page28.pdf" ],
+    "diameter_mm" : 9.53,
+    "diameter_inch" : 0.37519705299999995
+  },
+  "375 Winchester" : {
+    "name" : "375 Winchester",
+    "names" : [ "375 Win." ],
+    "specs" : {
+      "coal_mm" : 65.02,
+      "coal_inch" : 2.559843902
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page97.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  },
+  "376 Steyr" : {
+    "name" : "376 Steyr",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 79.0,
+      "coal_inch" : 3.1102379
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page144.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  },
+  "378 Weatherby Magnum" : {
+    "name" : "378 Weatherby Magnum",
+    "names" : [ "378 Weath.Mag." ],
+    "specs" : {
+      "coal_mm" : 92.84,
+      "coal_inch" : 3.655120084
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page29.pdf" ],
+    "diameter_mm" : 9.53,
+    "diameter_inch" : 0.37519705299999995
+  },
+  "38-40 Winchester" : {
+    "name" : "38-40 Winchester",
+    "names" : [ "38-40 Win." ],
+    "specs" : {
+      "coal_mm" : 40.44,
+      "coal_inch" : 1.5921268439999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page98.pdf" ],
+    "diameter_mm" : 10.17,
+    "diameter_inch" : 0.400393917
+  },
+  "38-55 Winchester" : {
+    "name" : "38-55 Winchester",
+    "names" : [ "38-55 Win." ],
+    "specs" : {
+      "coal_mm" : 63.75,
+      "coal_inch" : 2.509843875
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page99.pdf" ],
+    "diameter_mm" : 9.58,
+    "diameter_inch" : 0.377165558
+  },
+  "380 Long Rifle" : {
+    "name" : "380 Long Rifle",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 34.04,
+      "coal_inch" : 1.340158204
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page100.pdf" ],
+    "diameter_mm" : 9.47,
+    "diameter_inch" : 0.372834847
+  },
+  "4 Bore Rifle" : {
+    "name" : "4 Bore Rifle",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 119.3,
+      "coal_inch" : 4.6968529299999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page132.pdf" ],
+    "diameter_mm" : 25.4,
+    "diameter_inch" : 1.0000005399999998
+  },
+  "4.6 x 30" : {
+    "name" : "4.6 x 30",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 38.5,
+      "coal_inch" : 1.51574885
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/4-6-x-30-en.pdf" ],
+    "diameter_mm" : 4.65,
+    "diameter_inch" : 0.183070965
+  },
+  "40-60 Winchester" : {
+    "name" : "40-60 Winchester",
+    "names" : [ "40-60 Win" ],
+    "specs" : {
+      "coal_mm" : 57.28,
+      "coal_inch" : 2.255119328
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page101.pdf" ],
+    "diameter_mm" : 10.31,
+    "diameter_inch" : 0.405905731
+  },
+  "40-65 Winchester" : {
+    "name" : "40-65 Winchester",
+    "names" : [ "40-65 Win." ],
+    "specs" : {
+      "coal_mm" : 62.74,
+      "coal_inch" : 2.470080074
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/40-65-win-170428-en.pdf" ],
+    "diameter_mm" : 10.31,
+    "diameter_inch" : 0.405905731
+  },
+  "40-82 Winchester" : {
+    "name" : "40-82 Winchester",
+    "names" : [ "40-82 Win." ],
+    "specs" : {
+      "coal_mm" : 70.23,
+      "coal_inch" : 2.764962123
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page102.pdf" ],
+    "diameter_mm" : 10.35,
+    "diameter_inch" : 0.407480535
+  },
+  "400 Holland & Holland Belted Magnum" : {
+    "name" : "400 Holland & Holland Belted Magnum",
+    "names" : [ "400 H&H Belt. Mag." ],
+    "specs" : {
+      "coal_mm" : 90.0,
+      "coal_inch" : 3.543309
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page30.pdf" ],
+    "diameter_mm" : 10.44,
+    "diameter_inch" : 0.41102384399999997
+  },
+  "400 Purdey 3”" : {
+    "name" : "400 Purdey 3”",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page103.pdf" ],
+    "diameter_mm" : 10.29,
+    "diameter_inch" : 0.40511832899999994
+  },
+  "400/350 Nitro Express" : {
+    "name" : "400/350 Nitro Express",
+    "names" : [ "400/350 N.E." ],
+    "specs" : {
+      "coal_mm" : 93.73,
+      "coal_inch" : 3.690159473
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page104.pdf" ],
+    "diameter_mm" : 9.04,
+    "diameter_inch" : 0.35590570399999993
+  },
+  "401 Winchester Self-loading" : {
+    "name" : "401 Winchester Self-loading",
+    "names" : [ "401 Win. SL" ],
+    "specs" : {
+      "coal_mm" : 50.93,
+      "coal_inch" : 2.005119193
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page105.pdf" ],
+    "diameter_mm" : 10.34,
+    "diameter_inch" : 0.40708683399999995
+  },
+  "404 Rimless Nitro Express" : {
+    "name" : "404 Rimless Nitro Express",
+    "names" : [ "404 Riml. N.E." ],
+    "specs" : {
+      "coal_mm" : 89.66,
+      "coal_inch" : 3.5299231659999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page145.pdf" ],
+    "diameter_mm" : 10.72,
+    "diameter_inch" : 0.422047472
+  },
+  "405 Winchester" : {
+    "name" : "405 Winchester",
+    "names" : [ "405 Win." ],
+    "specs" : {
+      "coal_mm" : 80.64,
+      "coal_inch" : 3.174804864
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page106.pdf" ],
+    "diameter_mm" : 10.45,
+    "diameter_inch" : 0.41141754499999994
+  },
+  "408 Chey Tac" : {
+    "name" : "408 Chey Tac",
+    "names" : [ "10,36 x 77 mm" ],
+    "specs" : {
+      "coal_mm" : 115.5,
+      "coal_inch" : 4.54724655
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/408-chey-tac-en.pdf" ],
+    "diameter_mm" : 10.36,
+    "diameter_inch" : 0.40787423599999995
+  },
+  "408 Winchester" : {
+    "name" : "408 Winchester",
+    "names" : [ "408 Win." ],
+    "specs" : {
+      "coal_mm" : 65.53,
+      "coal_inch" : 2.579922653
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page107.pdf" ],
+    "diameter_mm" : 10.31,
+    "diameter_inch" : 0.405905731
+  },
+  "416 A-TEC" : {
+    "name" : "416 A-TEC",
+    "names" : [ "416 A-SUB" ],
+    "specs" : {
+      "coal_mm" : 71.0,
+      "coal_inch" : 2.7952771
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/416-a-tec-en.pdf" ],
+    "diameter_mm" : 10.57,
+    "diameter_inch" : 0.416141957
+  },
+  "416 Barrett" : {
+    "name" : "416 Barrett",
+    "names" : [ "10,4 x 83" ],
+    "specs" : {
+      "coal_mm" : 118.11,
+      "coal_inch" : 4.650002510999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/416-barrett-en.pdf" ],
+    "diameter_mm" : 10.57,
+    "diameter_inch" : 0.416141957
+  },
+  "416 Remington Magnum" : {
+    "name" : "416 Remington Magnum",
+    "names" : [ "416 Rem. Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page31.pdf" ],
+    "diameter_mm" : 10.57,
+    "diameter_inch" : 0.416141957
+  },
+  "416 Rigby" : {
+    "name" : "416 Rigby",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 95.25,
+      "coal_inch" : 3.7500020249999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page146.pdf" ],
+    "diameter_mm" : 10.57,
+    "diameter_inch" : 0.416141957
+  },
+  "416 Ruger" : {
+    "name" : "416 Ruger",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page147.pdf" ],
+    "diameter_mm" : 10.58,
+    "diameter_inch" : 0.416535658
+  },
+  "416 Taylor" : { },
+  "416 Taylor Magnum" : {
+    "name" : "416 Taylor Magnum",
+    "names" : [ "416 Taylor Mag." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/416-taylor-mag-en.pdf" ],
+    "diameter_mm" : 10.57,
+    "diameter_inch" : 0.416141957
+  },
+  "416 Weatherby Magnum" : {
+    "name" : "416 Weatherby Magnum",
+    "names" : [ "416 Weath.Mag." ],
+    "specs" : {
+      "coal_mm" : 95.25,
+      "coal_inch" : 3.7500020249999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page33.pdf" ],
+    "diameter_mm" : 10.57,
+    "diameter_inch" : 0.416141957
+  },
+  "44-40 Winchester" : {
+    "name" : "44-40 Winchester",
+    "names" : [ "44-40 Win." ],
+    "specs" : {
+      "coal_mm" : 40.44,
+      "coal_inch" : 1.5921268439999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page108.pdf" ],
+    "diameter_mm" : 10.85,
+    "diameter_inch" : 0.42716558499999996
+  },
+  "444 Marlin" : {
+    "name" : "444 Marlin",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 65.28,
+      "coal_inch" : 2.570080128
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page109.pdf" ],
+    "diameter_mm" : 10.93,
+    "diameter_inch" : 0.430315193
+  },
+  "45 Blaser" : {
+    "name" : "45 Blaser",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 68.5,
+      "coal_inch" : 2.69685185
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page148.pdf" ],
+    "diameter_mm" : 11.64,
+    "diameter_inch" : 0.458267964
+  },
+  "45-110 Sharps 2\" 7/8" : {
+    "name" : "45-110 Sharps 2\" 7/8",
+    "names" : [ "45-110 Sharps 2\"7/8" ],
+    "specs" : {
+      "coal_mm" : 85.3,
+      "coal_inch" : 3.35826953
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/45-110-sharps-170428-en.pdf" ],
+    "diameter_mm" : 11.63,
+    "diameter_inch" : 0.457874263
+  },
+  "45-120 Sharps 3\" 1/4" : {
+    "name" : "45-120 Sharps 3\" 1/4",
+    "names" : [ "45-120 Sharps 3\"1/4" ],
+    "specs" : {
+      "coal_mm" : 105.66,
+      "coal_inch" : 4.159844766
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/45-120-sharps-170428-en.pdf" ],
+    "diameter_mm" : 11.63,
+    "diameter_inch" : 0.457874263
+  },
+  "45-60 Winchester" : {
+    "name" : "45-60 Winchester",
+    "names" : [ "45-60 Win" ],
+    "specs" : {
+      "coal_mm" : 57.28,
+      "coal_inch" : 2.255119328
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page110.pdf" ],
+    "diameter_mm" : 11.66,
+    "diameter_inch" : 0.45905536599999996
+  },
+  "45-70 Elko Magnum" : {
+    "name" : "45-70 Elko Magnum",
+    "names" : [ "45-70 Elko Mag." ],
+    "specs" : {
+      "coal_mm" : 87.3,
+      "coal_inch" : 3.4370097299999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page111.pdf" ],
+    "diameter_mm" : 11.66,
+    "diameter_inch" : 0.45905536599999996
+  },
+  "45-70 Government" : {
+    "name" : "45-70 Government",
+    "names" : [ "45-70 Govt." ],
+    "specs" : {
+      "coal_mm" : 64.77,
+      "coal_inch" : 2.5500013769999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page112.pdf" ],
+    "diameter_mm" : 11.63,
+    "diameter_inch" : 0.457874263
+  },
+  "45-75 Winchester" : {
+    "name" : "45-75 Winchester",
+    "names" : [ "45-75 Win" ],
+    "specs" : {
+      "coal_mm" : 57.28,
+      "coal_inch" : 2.255119328
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page113.pdf" ],
+    "diameter_mm" : 11.66,
+    "diameter_inch" : 0.45905536599999996
+  },
+  "45-90 WM" : {
+    "name" : "45-90 WM",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page114.pdf" ],
+    "diameter_mm" : 11.63,
+    "diameter_inch" : 0.457874263
+  },
+  "450 Bushmaster" : {
+    "name" : "450 Bushmaster",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 57.4,
+      "coal_inch" : 2.25984374
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page149.pdf" ],
+    "diameter_mm" : 11.49,
+    "diameter_inch" : 0.452362449
+  },
+  "450 Marlin" : {
+    "name" : "450 Marlin",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 64.76,
+      "coal_inch" : 2.549607676
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page34.pdf" ],
+    "diameter_mm" : 11.64,
+    "diameter_inch" : 0.458267964
+  },
+  "450 Nitro Express 3\" 1/4" : {
+    "name" : "450 Nitro Express 3\" 1/4",
+    "names" : [ "450 N.E. 3\" 1/4" ],
+    "specs" : {
+      "coal_mm" : 100.33,
+      "coal_inch" : 3.950002133
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/450-ne-3-1-4-en.pdf" ],
+    "diameter_mm" : 11.63,
+    "diameter_inch" : 0.457874263
+  },
+  "450 N° 2 Nitro Express 3\" 1/2 Eley" : {
+    "name" : "450 N° 2 Nitro Express 3\" 1/2 Eley",
+    "names" : [ "450 N° 2 N.E. 3“1/2Eley" ],
+    "specs" : {
+      "coal_mm" : 109.98,
+      "coal_inch" : 4.329923598
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page116.pdf" ],
+    "diameter_mm" : 11.63,
+    "diameter_inch" : 0.457874263
+  },
+  "450 Rigby" : {
+    "name" : "450 Rigby",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 95.25,
+      "coal_inch" : 3.7500020249999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/450-rigby-en.pdf" ],
+    "diameter_mm" : 11.66,
+    "diameter_inch" : 0.45905536599999996
+  },
+  "450/400 Magnum Nitro Express 31/4" : {
+    "name" : "450/400 Magnum Nitro Express 31/4",
+    "names" : [ "450/400 Mag. N.E. 31/4" ],
+    "specs" : {
+      "coal_mm" : 100.33,
+      "coal_inch" : 3.950002133
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page118.pdf" ],
+    "diameter_mm" : 10.41,
+    "diameter_inch" : 0.409842741
+  },
+  "450/400 Nitro Express 3" : {
+    "name" : "450/400 Nitro Express 3",
+    "names" : [ "450/400 N.E. 3" ],
+    "specs" : {
+      "coal_mm" : 95.25,
+      "coal_inch" : 3.7500020249999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page117.pdf" ],
+    "diameter_mm" : 10.41,
+    "diameter_inch" : 0.409842741
+  },
+  "458 Lott" : {
+    "name" : "458 Lott",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/458-lott-en.pdf" ],
+    "diameter_mm" : 11.66,
+    "diameter_inch" : 0.45905536599999996
+  },
+  "458 Winchester Magnum" : {
+    "name" : "458 Winchester Magnum",
+    "names" : [ "458 Win. Mag." ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page36.pdf" ],
+    "diameter_mm" : 11.66,
+    "diameter_inch" : 0.45905536599999996
+  },
+  "460 Steyr" : {
+    "name" : "460 Steyr",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 140.0,
+      "coal_inch" : 5.511813999999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page151.pdf" ],
+    "diameter_mm" : 11.65,
+    "diameter_inch" : 0.458661665
+  },
+  "460 Weatherby Magnum" : {
+    "name" : "460 Weatherby Magnum",
+    "names" : [ "460 Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 95.25,
+      "coal_inch" : 3.7500020249999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page37.pdf" ],
+    "diameter_mm" : 11.64,
+    "diameter_inch" : 0.458267964
+  },
+  "465 Holland & Holland Belted Magnum" : {
+    "name" : "465 Holland & Holland Belted Magnum",
+    "names" : [ "465 H&H Belt. Mag." ],
+    "specs" : {
+      "coal_mm" : 90.0,
+      "coal_inch" : 3.543309
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page38.pdf" ],
+    "diameter_mm" : 11.89,
+    "diameter_inch" : 0.468110489
+  },
+  "470 Nitro Express" : {
+    "name" : "470 Nitro Express",
+    "names" : [ "470 N.E." ],
+    "specs" : {
+      "coal_mm" : 101.09,
+      "coal_inch" : 3.979923409
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/470-ne-en.pdf" ],
+    "diameter_mm" : 12.04,
+    "diameter_inch" : 0.47401600399999994
+  },
+  "475 N° 2 Nitro Express 3\" 1/2 Jeffery" : {
+    "name" : "475 N° 2 Nitro Express 3\" 1/2 Jeffery",
+    "names" : [ "475 N° 2 N.E. 3“1/2 Jeffery" ],
+    "specs" : {
+      "coal_mm" : 109.98,
+      "coal_inch" : 4.329923598
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page121.pdf" ],
+    "diameter_mm" : 12.39,
+    "diameter_inch" : 0.487795539
+  },
+  "475 N° 2 Nitro Express 31/2" : {
+    "name" : "475 N° 2 Nitro Express 31/2",
+    "names" : [ "475 N° 2 N.E. 31/2" ],
+    "specs" : {
+      "coal_mm" : 109.98,
+      "coal_inch" : 4.329923598
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page120.pdf" ],
+    "diameter_mm" : 12.27,
+    "diameter_inch" : 0.48307112699999993
+  },
+  "5.45 x 39" : {
+    "name" : "5.45 x 39",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 57.0,
+      "coal_inch" : 2.2440957
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/5-45-x-39-en.pdf" ],
+    "diameter_mm" : 5.6,
+    "diameter_inch" : 0.22047255999999998
+  },
+  "5.6 x 35 R" : {
+    "name" : "5.6 x 35 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 43.5,
+      "coal_inch" : 1.7125993499999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page1.pdf" ],
+    "diameter_mm" : 5.63,
+    "diameter_inch" : 0.22165366299999997
+  },
+  "5.6 x 39" : {
+    "name" : "5.6 x 39",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 48.7,
+      "coal_inch" : 1.91732387
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page3.pdf" ],
+    "diameter_mm" : 5.67,
+    "diameter_inch" : 0.22322846699999999
+  },
+  "5.6 x 50 Magnum" : {
+    "name" : "5.6 x 50 Magnum",
+    "names" : [ "5.6 x 50 Mag." ],
+    "specs" : {
+      "coal_mm" : 61.3,
+      "coal_inch" : 2.41338713
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page4.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "5.6 x 50 R Magnum" : {
+    "name" : "5.6 x 50 R Magnum",
+    "names" : [ "5.6 x 50 R Mag." ],
+    "specs" : {
+      "coal_mm" : 61.0,
+      "coal_inch" : 2.4015760999999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page2.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "5.6 x 52 R" : {
+    "name" : "5.6 x 52 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 63.75,
+      "coal_inch" : 2.509843875
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page3.pdf" ],
+    "diameter_mm" : 5.79,
+    "diameter_inch" : 0.227952879
+  },
+  "5.6 x 57" : {
+    "name" : "5.6 x 57",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 69.0,
+      "coal_inch" : 2.7165369
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page5.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "5.6 x 57 R" : {
+    "name" : "5.6 x 57 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 69.0,
+      "coal_inch" : 2.7165369
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page4.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "5.6 x 61 R Super Express Vom Hofe" : {
+    "name" : "5.6 x 61 R Super Express Vom Hofe",
+    "names" : [ "5.6 x 61 R SE v. H." ],
+    "specs" : {
+      "coal_mm" : 80.0,
+      "coal_inch" : 3.1496079999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page5.pdf" ],
+    "diameter_mm" : 5.76,
+    "diameter_inch" : 0.22677177599999998
+  },
+  "5.6 x 61 Super Express Vom Hofe" : {
+    "name" : "5.6 x 61 Super Express Vom Hofe",
+    "names" : [ "5.6 x 61 SE v. H." ],
+    "specs" : {
+      "coal_mm" : 80.0,
+      "coal_inch" : 3.1496079999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page6.pdf" ],
+    "diameter_mm" : 5.79,
+    "diameter_inch" : 0.227952879
+  },
+  "5.6 x 70 R" : {
+    "name" : "5.6 x 70 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.0,
+      "coal_inch" : 3.4251986999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page6.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "5.7 x 28" : {
+    "name" : "5.7 x 28",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 40.5,
+      "coal_inch" : 1.59448905
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page7.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "50 Browning" : {
+    "name" : "50 Browning",
+    "names" : [ "12,7 x 99" ],
+    "specs" : {
+      "coal_mm" : 138.43,
+      "coal_inch" : 5.450002943
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/50-browning-en.pdf" ],
+    "diameter_mm" : 12.98,
+    "diameter_inch" : 0.511023898
+  },
+  "50-70 Government" : {
+    "name" : "50-70 Government",
+    "names" : [ "50-70 Musket", "50-70 Govt." ],
+    "specs" : {
+      "coal_mm" : 57.15,
+      "coal_inch" : 2.2500012149999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/50-70-govt-170428-en.pdf" ],
+    "diameter_mm" : 13.08,
+    "diameter_inch" : 0.5149609079999999
+  },
+  "50-90 Sharps 2\" 1/2" : {
+    "name" : "50-90 Sharps 2\" 1/2",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 81.28,
+      "coal_inch" : 3.2000017279999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/50-90-sharps-170309-en.pdf" ],
+    "diameter_mm" : 13.08,
+    "diameter_inch" : 0.5149609079999999
+  },
+  "50-95 Winchester" : {
+    "name" : "50-95 Winchester",
+    "names" : [ "50-95 Win." ],
+    "specs" : {
+      "coal_mm" : 57.4,
+      "coal_inch" : 2.25984374
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page122.pdf" ],
+    "diameter_mm" : 13.03,
+    "diameter_inch" : 0.5129924029999999
+  },
+  "500 Jeffery" : {
+    "name" : "500 Jeffery",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 88.09,
+      "coal_inch" : 3.4681121089999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page153.pdf" ],
+    "diameter_mm" : 12.95,
+    "diameter_inch" : 0.509842795
+  },
+  "500 Nitro Express 3\"" : {
+    "name" : "500 Nitro Express 3\"",
+    "names" : [ "500 N.E. 3\"" ],
+    "specs" : {
+      "coal_mm" : 95.25,
+      "coal_inch" : 3.7500020249999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/500-n-e-3-en.pdf" ],
+    "diameter_mm" : 12.95,
+    "diameter_inch" : 0.509842795
+  },
+  "500/416 Nitro Express 3\" 1/4" : {
+    "name" : "500/416 Nitro Express 3\" 1/4",
+    "names" : [ "500/416 N.E. 3“1/4" ],
+    "specs" : {
+      "coal_mm" : 101.09,
+      "coal_inch" : 3.979923409
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page124.pdf" ],
+    "diameter_mm" : 10.57,
+    "diameter_inch" : 0.416141957
+  },
+  "500/465 Nitro Express" : {
+    "name" : "500/465 Nitro Express",
+    "names" : [ "500/465 N.E." ],
+    "specs" : {
+      "coal_mm" : 99.06,
+      "coal_inch" : 3.900002106
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page125.pdf" ],
+    "diameter_mm" : 11.89,
+    "diameter_inch" : 0.468110489
+  },
+  "505 Magnum Gibbs" : {
+    "name" : "505 Magnum Gibbs",
+    "names" : [ "505 Mag. Gibbs" ],
+    "specs" : {
+      "coal_mm" : 97.79,
+      "coal_inch" : 3.8500020790000002
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page154.pdf" ],
+    "diameter_mm" : 12.83,
+    "diameter_inch" : 0.505118383
+  },
+  "510 DTC" : {
+    "name" : "510 DTC",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 137.47,
+      "coal_inch" : 5.412207647
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page155.pdf" ],
+    "diameter_mm" : 12.98,
+    "diameter_inch" : 0.511023898
+  },
+  "56/50 Spencer" : {
+    "name" : "56/50 Spencer",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 38.56,
+      "coal_inch" : 1.518111056
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page126.pdf" ],
+    "diameter_mm" : 13.0,
+    "diameter_inch" : 0.5118113
+  },
+  "577 Nitro Express 3\"" : {
+    "name" : "577 Nitro Express 3\"",
+    "names" : [ "577 N.E. 3\"" ],
+    "specs" : {
+      "coal_mm" : 93.98,
+      "coal_inch" : 3.700001998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/577-ne-3-en.pdf" ],
+    "diameter_mm" : 14.83,
+    "diameter_inch" : 0.5838585829999999
+  },
+  "577 Sld. Snider" : {
+    "name" : "577 Sld. Snider",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 62.74,
+      "coal_inch" : 2.470080074
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page129.pdf" ],
+    "diameter_mm" : 14.58,
+    "diameter_inch" : 0.574016058
+  },
+  "577/450 Sld. Martini–Henry" : {
+    "name" : "577/450 Sld. Martini–Henry",
+    "names" : [ "577/450 Sld. Mart.H." ],
+    "specs" : {
+      "coal_mm" : 81.28,
+      "coal_inch" : 3.2000017279999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page127.pdf" ],
+    "diameter_mm" : 11.81,
+    "diameter_inch" : 0.464960881
+  },
+  "5mm / 35 SMc" : {
+    "name" : "5mm / 35 SMc",
+    "names" : [ "5 mm / 35 SMc" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page1.pdf" ]
+  },
+  "6 XC" : {
+    "name" : "6 XC",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 70.0,
+      "coal_inch" : 2.7559069999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page17.pdf" ],
+    "diameter_mm" : 6.18,
+    "diameter_inch" : 0.24330721799999996
+  },
+  "6 x 47 ATZL" : {
+    "name" : "6 x 47 ATZL",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 63.0,
+      "coal_inch" : 2.4803162999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-x-47-atzl-en.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6 x 47 SM" : {
+    "name" : "6 x 47 SM",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 66.0,
+      "coal_inch" : 2.5984266
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page9.pdf" ],
+    "diameter_mm" : 6.18,
+    "diameter_inch" : 0.24330721799999996
+  },
+  "6 x 50 R Scheiring" : {
+    "name" : "6 x 50 R Scheiring",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 69.0,
+      "coal_inch" : 2.7165369
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page7.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6 x 51 ATZL" : {
+    "name" : "6 x 51 ATZL",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 68.0,
+      "coal_inch" : 2.6771667999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page10.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6 x 52 R BB2" : {
+    "name" : "6 x 52 R BB2",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 69.0,
+      "coal_inch" : 2.7165369
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page8.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6 x 52 R Bretschneider" : {
+    "name" : "6 x 52 R Bretschneider",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 68.5,
+      "coal_inch" : 2.69685185
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page9.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6 x 62 Freres" : {
+    "name" : "6 x 62 Freres",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page11.pdf" ],
+    "diameter_mm" : 6.18,
+    "diameter_inch" : 0.24330721799999996
+  },
+  "6 x 62 R Freres" : {
+    "name" : "6 x 62 R Freres",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page10.pdf" ],
+    "diameter_mm" : 6.18,
+    "diameter_inch" : 0.24330721799999996
+  },
+  "6 x 70 R" : {
+    "name" : "6 x 70 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.0,
+      "coal_inch" : 3.4251986999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page11.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6.3 x 57 Farè" : {
+    "name" : "6.3 x 57 Farè",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 75.0,
+      "coal_inch" : 2.9527574999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-3-x-57-fare-en.pdf" ],
+    "diameter_mm" : 6.52,
+    "diameter_inch" : 0.256693052
+  },
+  "6.5 - 284 Norma" : {
+    "name" : "6.5 - 284 Norma",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page18.pdf" ],
+    "diameter_mm" : 6.71,
+    "diameter_inch" : 0.264173371
+  },
+  "6.5 Creedmoor" : {
+    "name" : "6.5 Creedmoor",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 71.76,
+      "coal_inch" : 2.825198376
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-creedmoor-en.pdf" ],
+    "diameter_mm" : 6.72,
+    "diameter_inch" : 0.26456707199999996
+  },
+  "6.5 Grendel" : {
+    "name" : "6.5 Grendel",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6.pdf" ]
+  },
+  "6.5 x 39" : {
+    "name" : "6.5 x 39",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 56.0,
+      "coal_inch" : 2.2047255999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-39-en.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 47 Lapua" : {
+    "name" : "6.5 x 47 Lapua",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 71.0,
+      "coal_inch" : 2.7952771
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-47-lapua-en.pdf" ],
+    "diameter_mm" : 6.71,
+    "diameter_inch" : 0.264173371
+  },
+  "6.5 x 50 R" : {
+    "name" : "6.5 x 50 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 68.0,
+      "coal_inch" : 2.6771667999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page12.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 51 R (Arisaka)" : {
+    "name" : "6.5 x 51 R (Arisaka)",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 76.0,
+      "coal_inch" : 2.9921276
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/6-5-x-51-r-arisaka-en.pdf" ],
+    "diameter_mm" : 6.63,
+    "diameter_inch" : 0.26102376299999996
+  },
+  "6.5 x 52 Carcano" : {
+    "name" : "6.5 x 52 Carcano",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 76.5,
+      "coal_inch" : 3.01181265
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-52-carcano-en.pdf" ],
+    "diameter_mm" : 6.8,
+    "diameter_inch" : 0.26771668
+  },
+  "6.5 x 52 R" : {
+    "name" : "6.5 x 52 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 64.5,
+      "coal_inch" : 2.53937145
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page14.pdf" ],
+    "diameter_mm" : 6.58,
+    "diameter_inch" : 0.259055258
+  },
+  "6.5 x 52 R Keller & Simmann" : {
+    "name" : "6.5 x 52 R Keller & Simmann",
+    "names" : [ "6.5 x 52 R K&S" ],
+    "specs" : {
+      "coal_mm" : 71.12,
+      "coal_inch" : 2.800001512
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/6-5-x-52-r-k-s-en.pdf" ],
+    "diameter_mm" : 6.72,
+    "diameter_inch" : 0.26456707199999996
+  },
+  "6.5 x 54 Mannlicher–Schönauer" : {
+    "name" : "6.5 x 54 Mannlicher–Schönauer",
+    "names" : [ "6.5 x 54 M.-Sch." ],
+    "specs" : {
+      "coal_mm" : 77.8,
+      "coal_inch" : 3.0629937799999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page22.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 54 Mauser" : {
+    "name" : "6.5 x 54 Mauser",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 68.0,
+      "coal_inch" : 2.6771667999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page21.pdf" ],
+    "diameter_mm" : 6.64,
+    "diameter_inch" : 0.261417464
+  },
+  "6.5 x 55 SE" : {
+    "name" : "6.5 x 55 SE",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 80.0,
+      "coal_inch" : 3.1496079999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-55-se-en.pdf" ],
+    "diameter_mm" : 6.71,
+    "diameter_inch" : 0.264173371
+  },
+  "6.5 x 55 T.R.I." : {
+    "name" : "6.5 x 55 T.R.I.",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-55-t.pdf" ]
+  },
+  "6.5 x 57" : {
+    "name" : "6.5 x 57",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page24.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 57 R" : {
+    "name" : "6.5 x 57 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page15.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 58 Mauser" : {
+    "name" : "6.5 x 58 Mauser",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.5,
+      "coal_inch" : 3.2480332499999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page25.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 58 R" : {
+    "name" : "6.5 x 58 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.0,
+      "coal_inch" : 3.0708678
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page16.pdf" ],
+    "diameter_mm" : 6.64,
+    "diameter_inch" : 0.261417464
+  },
+  "6.5 x 63 Messner Magnum" : {
+    "name" : "6.5 x 63 Messner Magnum",
+    "names" : [ "6.5 x 63 Messner Mag." ],
+    "specs" : {
+      "coal_mm" : 84.5,
+      "coal_inch" : 3.3267734499999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page26.pdf" ],
+    "diameter_mm" : 6.71,
+    "diameter_inch" : 0.264173371
+  },
+  "6.5 x 64" : {
+    "name" : "6.5 x 64",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.0,
+      "coal_inch" : 3.3070884
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page27.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 64 Brenneke" : {
+    "name" : "6.5 x 64 Brenneke",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.84,
+      "coal_inch" : 3.340159284
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-64-brenneke-en.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 65 R Rheinisch-Westfälischen Sprengstoff-Fabriken" : {
+    "name" : "6.5 x 65 R Rheinisch-Westfälischen Sprengstoff-Fabriken",
+    "names" : [ "6.5 x 65 R RWS" ],
+    "specs" : {
+      "coal_mm" : 85.0,
+      "coal_inch" : 3.3464585
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page17.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 65 Rheinisch-Westfälischen Sprengstoff-Fabriken" : {
+    "name" : "6.5 x 65 Rheinisch-Westfälischen Sprengstoff-Fabriken",
+    "names" : [ "6.5 x 65 RWS" ],
+    "specs" : {
+      "coal_mm" : 85.0,
+      "coal_inch" : 3.3464585
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page29.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 68" : {
+    "name" : "6.5 x 68",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 86.5,
+      "coal_inch" : 3.40551365
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page30.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 68 R" : {
+    "name" : "6.5 x 68 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.5,
+      "coal_inch" : 3.44488375
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page18.pdf" ],
+    "diameter_mm" : 6.7,
+    "diameter_inch" : 0.26377967
+  },
+  "6.5 x 70 R" : {
+    "name" : "6.5 x 70 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 90.0,
+      "coal_inch" : 3.543309
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page19.pdf" ],
+    "diameter_mm" : 6.64,
+    "diameter_inch" : 0.261417464
+  },
+  "6.5mm D.B.G." : {
+    "name" : "6.5mm D.B.G.",
+    "names" : [ "6.5 mm D.B.G." ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-mm-d.pdf" ]
+  },
+  "6.5mm Lahoz" : {
+    "name" : "6.5mm Lahoz",
+    "names" : [ "6.5 mm Lahoz" ],
+    "specs" : {
+      "coal_mm" : 57.4,
+      "coal_inch" : 2.25984374
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-mm-lahoz-en.pdf" ],
+    "diameter_mm" : 6.71,
+    "diameter_inch" : 0.264173371
+  },
+  "6.5mm Remington Magnum" : {
+    "name" : "6.5mm Remington Magnum",
+    "names" : [ "6.5 mm Rem. Mag." ],
+    "specs" : {
+      "coal_mm" : 71.12,
+      "coal_inch" : 2.800001512
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page1.pdf" ],
+    "diameter_mm" : 6.72,
+    "diameter_inch" : 0.26456707199999996
+  },
+  "6.8mm Remington Special Purpose Cartridge" : {
+    "name" : "6.8mm Remington Special Purpose Cartridge",
+    "names" : [ "6.8 mm Rem. SPC" ],
+    "specs" : {
+      "coal_mm" : 57.4,
+      "coal_inch" : 2.25984374
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page31.pdf" ],
+    "diameter_mm" : 7.06,
+    "diameter_inch" : 0.27795290599999994
+  },
+  "600 Nitro Express" : {
+    "name" : "600 Nitro Express",
+    "names" : [ "600 N.E." ],
+    "specs" : {
+      "coal_mm" : 93.98,
+      "coal_inch" : 3.700001998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page130.pdf" ],
+    "diameter_mm" : 15.75,
+    "diameter_inch" : 0.6200790749999999
+  },
+  "6mm Bench Rest Farè" : {
+    "name" : "6mm Bench Rest Farè",
+    "names" : [ "6 mm BR Farè" ],
+    "specs" : {
+      "coal_mm" : 62.0,
+      "coal_inch" : 2.4409462
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-mm-br-fare-en.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6mm Bench Rest Norma" : {
+    "name" : "6mm Bench Rest Norma",
+    "names" : [ "6 mm BR Norma" ],
+    "specs" : {
+      "coal_mm" : 62.0,
+      "coal_inch" : 2.4409462
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page12.pdf" ],
+    "diameter_mm" : 6.18,
+    "diameter_inch" : 0.24330721799999996
+  },
+  "6mm Bench Rest Remington" : {
+    "name" : "6mm Bench Rest Remington",
+    "names" : [ "6 mm B.R. Rem." ],
+    "specs" : {
+      "coal_mm" : 55.88,
+      "coal_inch" : 2.200001188
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page13.pdf" ],
+    "diameter_mm" : 6.18,
+    "diameter_inch" : 0.24330721799999996
+  },
+  "6mm D.B.G." : {
+    "name" : "6mm D.B.G.",
+    "names" : [ "6 mm D.B.G." ],
+    "specs" : {
+      "coal_mm" : 58.0,
+      "coal_inch" : 2.2834658
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-mm-dbg-en.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6mm Palmisano & Pindel Cartridge" : {
+    "name" : "6mm Palmisano & Pindel Cartridge",
+    "names" : [ "6 mm PPC" ],
+    "specs" : {
+      "coal_mm" : 55.7,
+      "coal_inch" : 2.19291457
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page14.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6mm Palmisano & Pindel Cartridge ITA" : {
+    "name" : "6mm Palmisano & Pindel Cartridge ITA",
+    "names" : [ "6 mm PPC ITA" ],
+    "specs" : {
+      "coal_mm" : 55.7,
+      "coal_inch" : 2.19291457
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-mm-ppc-ita-en.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6mm Palmisano & Pindel Cartridge-USA" : {
+    "name" : "6mm Palmisano & Pindel Cartridge-USA",
+    "names" : [ "6 mm PPC-USA" ],
+    "specs" : {
+      "coal_mm" : 55.7,
+      "coal_inch" : 2.19291457
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page15.pdf" ],
+    "diameter_mm" : 6.17,
+    "diameter_inch" : 0.242913517
+  },
+  "6mm Remington (244 Remington)" : {
+    "name" : "6mm Remington (244 Remington)",
+    "names" : [ "6 mm Rem. (244 Rem.)" ],
+    "specs" : {
+      "coal_mm" : 71.76,
+      "coal_inch" : 2.825198376
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page16.pdf" ],
+    "diameter_mm" : 6.18,
+    "diameter_inch" : 0.24330721799999996
+  },
+  "7 x 33 Sako" : {
+    "name" : "7 x 33 Sako",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 44.44,
+      "coal_inch" : 1.749607244
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page32.pdf" ],
+    "diameter_mm" : 7.26,
+    "diameter_inch" : 0.285826926
+  },
+  "7 x 44 Penna" : {
+    "name" : "7 x 44 Penna",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 60.0,
+      "coal_inch" : 2.362206
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-x-44-penna-en.pdf" ],
+    "diameter_mm" : 7.04,
+    "diameter_inch" : 0.277165504
+  },
+  "7 x 50 R" : {
+    "name" : "7 x 50 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 68.0,
+      "coal_inch" : 2.6771667999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page21.pdf" ],
+    "diameter_mm" : 7.25,
+    "diameter_inch" : 0.285433225
+  },
+  "7 x 57" : {
+    "name" : "7 x 57",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.0,
+      "coal_inch" : 3.0708678
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page33.pdf" ],
+    "diameter_mm" : 7.25,
+    "diameter_inch" : 0.285433225
+  },
+  "7 x 57 R" : {
+    "name" : "7 x 57 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.0,
+      "coal_inch" : 3.0708678
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/7-x-57-r-en.pdf" ],
+    "diameter_mm" : 7.25,
+    "diameter_inch" : 0.285433225
+  },
+  "7 x 61 Super" : {
+    "name" : "7 x 61 Super",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 83.0,
+      "coal_inch" : 3.2677183
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/7-x-61-super-en.pdf" ],
+    "diameter_mm" : 7.2,
+    "diameter_inch" : 0.28346472
+  },
+  "7 x 64" : {
+    "name" : "7 x 64",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.0,
+      "coal_inch" : 3.3070884
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page34.pdf" ],
+    "diameter_mm" : 7.25,
+    "diameter_inch" : 0.285433225
+  },
+  "7 x 65 R" : {
+    "name" : "7 x 65 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 83.6,
+      "coal_inch" : 3.2913403599999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page24.pdf" ],
+    "diameter_mm" : 7.25,
+    "diameter_inch" : 0.285433225
+  },
+  "7 x 67 R Luyven" : {
+    "name" : "7 x 67 R Luyven",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 90.0,
+      "coal_inch" : 3.543309
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page25.pdf" ],
+    "diameter_mm" : 7.25,
+    "diameter_inch" : 0.285433225
+  },
+  "7 x 72 R" : {
+    "name" : "7 x 72 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 92.0,
+      "coal_inch" : 3.6220491999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page26.pdf" ],
+    "diameter_mm" : 7.25,
+    "diameter_inch" : 0.285433225
+  },
+  "7 x 75 R Super Express Vom Hofe" : {
+    "name" : "7 x 75 R Super Express Vom Hofe",
+    "names" : [ "7 x 75 R SE.v. H." ],
+    "specs" : {
+      "coal_mm" : 97.0,
+      "coal_inch" : 3.8188997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page27.pdf" ],
+    "diameter_mm" : 7.24,
+    "diameter_inch" : 0.285039524
+  },
+  "7-30 Waters" : {
+    "name" : "7-30 Waters",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 64.77,
+      "coal_inch" : 2.5500013769999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page20.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7-47 Giani Special" : {
+    "name" : "7-47 Giani Special",
+    "names" : [ "7-47 GS" ],
+    "specs" : {
+      "coal_mm" : 71.0,
+      "coal_inch" : 2.7952771
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-47-gs-en.pdf" ],
+    "diameter_mm" : 7.06,
+    "diameter_inch" : 0.27795290599999994
+  },
+  "7.21 Firebird" : {
+    "name" : "7.21 Firebird",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 92.2,
+      "coal_inch" : 3.62992322
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page44.pdf" ],
+    "diameter_mm" : 7.24,
+    "diameter_inch" : 0.285039524
+  },
+  "7.5 x 54 Manufacture d'armes de Saint-Étienne" : {
+    "name" : "7.5 x 54 Manufacture d'armes de Saint-Étienne",
+    "names" : [ "7.5 x 54 MAS" ],
+    "specs" : {
+      "coal_mm" : 76.0,
+      "coal_inch" : 2.9921276
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-5-x-54-mas-en.pdf" ],
+    "diameter_mm" : 7.84,
+    "diameter_inch" : 0.308661584
+  },
+  "7.5 x 55 Suisse" : {
+    "name" : "7.5 x 55 Suisse",
+    "names" : [ "7,5 x 55 Swiss" ],
+    "specs" : {
+      "coal_mm" : 77.7,
+      "coal_inch" : 3.0590567699999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-5-x-55-suisse-en.pdf" ],
+    "diameter_mm" : 7.78,
+    "diameter_inch" : 0.306299378
+  },
+  "7.62 Uekötter Katzmeier Magnum" : {
+    "name" : "7.62 Uekötter Katzmeier Magnum",
+    "names" : [ "7.62 UKM" ],
+    "specs" : {
+      "coal_mm" : 79.0,
+      "coal_inch" : 3.1102379
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page49.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "7.62 x 39" : {
+    "name" : "7.62 x 39",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 56.0,
+      "coal_inch" : 2.2047255999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-62-x-39-en.pdf" ],
+    "diameter_mm" : 7.92,
+    "diameter_inch" : 0.31181119199999996
+  },
+  "7.62 x 45" : {
+    "name" : "7.62 x 45",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 60.0,
+      "coal_inch" : 2.362206
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page48.pdf" ],
+    "diameter_mm" : 7.83,
+    "diameter_inch" : 0.30826788299999996
+  },
+  "7.62 x 53 R" : {
+    "name" : "7.62 x 53 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 77.0,
+      "coal_inch" : 3.0314977
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page28.pdf" ],
+    "diameter_mm" : 7.85,
+    "diameter_inch" : 0.30905528499999996
+  },
+  "7.62 x 54 R" : {
+    "name" : "7.62 x 54 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 77.16,
+      "coal_inch" : 3.0377969159999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/7-62-x-54-r-en.pdf" ],
+    "diameter_mm" : 7.92,
+    "diameter_inch" : 0.31181119199999996
+  },
+  "7.65 x 53 Argentine" : {
+    "name" : "7.65 x 53 Argentine",
+    "names" : [ "7.65 x 53 Arg." ],
+    "specs" : {
+      "coal_mm" : 76.0,
+      "coal_inch" : 2.9921276
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page50.pdf" ],
+    "diameter_mm" : 7.94,
+    "diameter_inch" : 0.312598594
+  },
+  "7.82 Warbird" : {
+    "name" : "7.82 Warbird",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 92.2,
+      "coal_inch" : 3.62992322
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page51.pdf" ],
+    "diameter_mm" : 7.84,
+    "diameter_inch" : 0.308661584
+  },
+  "7.92 x 24 Van Bruaene Rik" : {
+    "name" : "7.92 x 24 Van Bruaene Rik",
+    "names" : [ "7.92 x 24 VBR" ],
+    "specs" : {
+      "coal_mm" : 32.1,
+      "coal_inch" : 1.26378021
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page52.pdf" ],
+    "diameter_mm" : 7.92,
+    "diameter_inch" : 0.31181119199999996
+  },
+  "7.92 x 33 kurz" : {
+    "name" : "7.92 x 33 kurz",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 48.0,
+      "coal_inch" : 1.8897648
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-92-x-33-kurz-en.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "700 Holland & Holland Nitro Express" : {
+    "name" : "700 Holland & Holland Nitro Express",
+    "names" : [ "700 H&H Nitro Exp." ],
+    "specs" : {
+      "coal_mm" : 106.68,
+      "coal_inch" : 4.200002268
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page131.pdf" ],
+    "diameter_mm" : 17.78,
+    "diameter_inch" : 0.700000378
+  },
+  "7mm - 08 Remington" : {
+    "name" : "7mm - 08 Remington",
+    "names" : [ "7 mm - 08 Rem." ],
+    "specs" : {
+      "coal_mm" : 71.12,
+      "coal_inch" : 2.800001512
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page35.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7mm Bench Rest Remington" : {
+    "name" : "7mm Bench Rest Remington",
+    "names" : [ "7 mm B.R. Rem." ],
+    "specs" : {
+      "coal_mm" : 54.42,
+      "coal_inch" : 2.142520842
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page37.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7mm Blaser Magnum" : {
+    "name" : "7mm Blaser Magnum",
+    "names" : [ "7 mm Blaser Mag." ],
+    "specs" : {
+      "coal_mm" : 80.0,
+      "coal_inch" : 3.1496079999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page36.pdf" ],
+    "diameter_mm" : 7.22,
+    "diameter_inch" : 0.284252122
+  },
+  "7mm Express Remington" : {
+    "name" : "7mm Express Remington",
+    "names" : [ "7 mm Exp. Rem." ],
+    "specs" : {
+      "coal_mm" : 84.58,
+      "coal_inch" : 3.329923058
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page38.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7mm KM" : {
+    "name" : "7mm KM",
+    "names" : [ "7 mm KM" ],
+    "specs" : {
+      "coal_mm" : 93.5,
+      "coal_inch" : 3.68110435
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-mm-km-en.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7mm Magnum Flanged Holland & Holland" : {
+    "name" : "7mm Magnum Flanged Holland & Holland",
+    "names" : [ "7 mm Mag.Fl. H&H" ],
+    "specs" : {
+      "coal_mm" : 82.8,
+      "coal_inch" : 3.25984428
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page23.pdf" ],
+    "diameter_mm" : 7.21,
+    "diameter_inch" : 0.28385842099999997
+  },
+  "7mm Remington Magnum" : {
+    "name" : "7mm Remington Magnum",
+    "names" : [ "7 mm Rem. Mag." ],
+    "specs" : {
+      "coal_mm" : 83.57,
+      "coal_inch" : 3.2901592569999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page3.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7mm Remington Short Action Ultra Magnum" : {
+    "name" : "7mm Remington Short Action Ultra Magnum",
+    "names" : [ "7 mm Rem. SA Ultra Mag." ],
+    "specs" : {
+      "coal_mm" : 71.76,
+      "coal_inch" : 2.825198376
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page40.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7mm Remington Ultra Magnum" : {
+    "name" : "7mm Remington Ultra Magnum",
+    "names" : [ "7 mm Rem. Ultra Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page41.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7mm Rosè" : {
+    "name" : "7mm Rosè",
+    "names" : [ "7 mm Rosè" ],
+    "specs" : {
+      "coal_mm" : 83.57,
+      "coal_inch" : 3.2901592569999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/7-mm-rose-170223-en.pdf" ],
+    "diameter_mm" : 7.22,
+    "diameter_inch" : 0.284252122
+  },
+  "7mm Shooting Times Westerner" : {
+    "name" : "7mm Shooting Times Westerner",
+    "names" : [ "7 mm STW" ],
+    "specs" : {
+      "coal_mm" : 92.71,
+      "coal_inch" : 3.6500019709999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page4.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "7mm Super Express Vom Hofe" : {
+    "name" : "7mm Super Express Vom Hofe",
+    "names" : [ "7 mm SE v.H." ],
+    "specs" : {
+      "coal_mm" : 84.0,
+      "coal_inch" : 3.3070884
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page42.pdf" ],
+    "diameter_mm" : 7.24,
+    "diameter_inch" : 0.285039524
+  },
+  "7mm Weatherby Magnum" : {
+    "name" : "7mm Weatherby Magnum",
+    "names" : [ "7 mm Weath. Mag." ],
+    "specs" : {
+      "coal_mm" : 85.34,
+      "coal_inch" : 3.359844334
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page5.pdf" ],
+    "diameter_mm" : 7.22,
+    "diameter_inch" : 0.284252122
+  },
+  "7mm Winchester Short Magnum" : {
+    "name" : "7mm Winchester Short Magnum",
+    "names" : [ "7 mm Win. Short Mag." ],
+    "specs" : {
+      "coal_mm" : 72.64,
+      "coal_inch" : 2.859844064
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-mm-win-short-mag-en.pdf" ],
+    "diameter_mm" : 7.23,
+    "diameter_inch" : 0.284645823
+  },
+  "8 x 50 R" : {
+    "name" : "8 x 50 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 76.0,
+      "coal_inch" : 2.9921276
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page30.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8 x 51 (Mauser K)" : {
+    "name" : "8 x 51 (Mauser K)",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 68.0,
+      "coal_inch" : 2.6771667999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page54.pdf" ],
+    "diameter_mm" : 8.07,
+    "diameter_inch" : 0.317716707
+  },
+  "8 x 51 R Lebel" : {
+    "name" : "8 x 51 R Lebel",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/8-x-51-r-lebel.pdf" ]
+  },
+  "8 x 56 Mannlicher–Schönauer" : {
+    "name" : "8 x 56 Mannlicher–Schönauer",
+    "names" : [ "8 x 56 M.-Sch." ],
+    "specs" : {
+      "coal_mm" : 77.8,
+      "coal_inch" : 3.0629937799999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page55.pdf" ],
+    "diameter_mm" : 8.25,
+    "diameter_inch" : 0.324803325
+  },
+  "8 x 56 R M30S" : {
+    "name" : "8 x 56 R M30S",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 76.5,
+      "coal_inch" : 3.01181265
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page31.pdf" ],
+    "diameter_mm" : 8.4,
+    "diameter_inch" : 0.33070884
+  },
+  "8 x 56 R M89 Portuguese Kropatschek" : {
+    "name" : "8 x 56 R M89 Portuguese Kropatschek",
+    "names" : [ "8 x 56 R M89 Port. Krop." ],
+    "specs" : {
+      "coal_mm" : 81.0,
+      "coal_inch" : 3.1889781
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page32.pdf" ],
+    "diameter_mm" : 8.2,
+    "diameter_inch" : 0.32283481999999997
+  },
+  "8 x 57 I" : {
+    "name" : "8 x 57 I",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page56.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 57 IR" : {
+    "name" : "8 x 57 IR",
+    "names" : [ "8 x 57 JR" ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/8-x-57-ir-en.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 57 IRS" : {
+    "name" : "8 x 57 IRS",
+    "names" : [ "8 x 57 JRS" ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/8-x-57-irs-en.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8 x 57 IS" : {
+    "name" : "8 x 57 IS",
+    "names" : [ "8 x 57 JS" ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/8-x-57-is-en.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8 x 57 PCC" : {
+    "name" : "8 x 57 PCC",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page58.pdf" ],
+    "diameter_mm" : 8.2,
+    "diameter_inch" : 0.32283481999999997
+  },
+  "8 x 57 R 360" : {
+    "name" : "8 x 57 R 360",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 77.0,
+      "coal_inch" : 3.0314977
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page33.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 58 R" : {
+    "name" : "8 x 58 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 78.0,
+      "coal_inch" : 3.0708678
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page36.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 60" : {
+    "name" : "8 x 60",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/8-x-60-en.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 60 R" : {
+    "name" : "8 x 60 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page37.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 60 RS" : {
+    "name" : "8 x 60 RS",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 83.6,
+      "coal_inch" : 3.2913403599999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page38.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8 x 60 S" : {
+    "name" : "8 x 60 S",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page60.pdf" ]
+  },
+  "8 x 64" : {
+    "name" : "8 x 64",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 86.0,
+      "coal_inch" : 3.3858286
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page61.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 64 S" : {
+    "name" : "8 x 64 S",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.5,
+      "coal_inch" : 3.44488375
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page62.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8 x 65 R" : {
+    "name" : "8 x 65 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 86.0,
+      "coal_inch" : 3.3858286
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page39.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 65 RS" : {
+    "name" : "8 x 65 RS",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.5,
+      "coal_inch" : 3.44488375
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page40.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8 x 68 S" : {
+    "name" : "8 x 68 S",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.0,
+      "coal_inch" : 3.4251986999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page63.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8 x 72 R" : {
+    "name" : "8 x 72 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 98.0,
+      "coal_inch" : 3.8582698
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page41.pdf" ],
+    "diameter_mm" : 8.09,
+    "diameter_inch" : 0.318504109
+  },
+  "8 x 75 RS" : {
+    "name" : "8 x 75 RS",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 96.0,
+      "coal_inch" : 3.7795296
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page42.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8 x 75 S" : {
+    "name" : "8 x 75 S",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 96.0,
+      "coal_inch" : 3.7795296
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page64.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8.15 x 46 R" : {
+    "name" : "8.15 x 46 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 62.3,
+      "coal_inch" : 2.4527572299999996
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page44.pdf" ],
+    "diameter_mm" : 8.38,
+    "diameter_inch" : 0.329921438
+  },
+  "8.2 x 53 R" : {
+    "name" : "8.2 x 53 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 76.0,
+      "coal_inch" : 2.9921276
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page45.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8.5 x 63" : {
+    "name" : "8.5 x 63",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.0,
+      "coal_inch" : 3.3070884
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page65.pdf" ],
+    "diameter_mm" : 8.61,
+    "diameter_inch" : 0.33897656099999995
+  },
+  "8.5 x 63 R" : {
+    "name" : "8.5 x 63 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 84.0,
+      "coal_inch" : 3.3070884
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page46.pdf" ],
+    "diameter_mm" : 8.59,
+    "diameter_inch" : 0.33818915899999996
+  },
+  "8.5 x 68 Fanzoj" : {
+    "name" : "8.5 x 68 Fanzoj",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 87.0,
+      "coal_inch" : 3.4251986999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/8-5-x-68-fanzoj-en.pdf" ],
+    "diameter_mm" : 8.59,
+    "diameter_inch" : 0.33818915899999996
+  },
+  "8.5 x 75 R Scheiring" : {
+    "name" : "8.5 x 75 R Scheiring",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 96.0,
+      "coal_inch" : 3.7795296
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/8-5-x-75-r-scheiring-en.pdf" ],
+    "diameter_mm" : 8.61,
+    "diameter_inch" : 0.33897656099999995
+  },
+  "8.5mm Messner Magnum" : {
+    "name" : "8.5mm Messner Magnum",
+    "names" : [ "8.5 mm Messner Mag." ],
+    "specs" : {
+      "coal_mm" : 88.0,
+      "coal_inch" : 3.4645688
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/8-5-mm-messner-mag-en.pdf" ],
+    "diameter_mm" : 8.59,
+    "diameter_inch" : 0.33818915899999996
+  },
+  "8mm Remington Magnum" : {
+    "name" : "8mm Remington Magnum",
+    "names" : [ "8 mm Rem.Mag." ],
+    "specs" : {
+      "coal_mm" : 91.44,
+      "coal_inch" : 3.6000019439999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page6.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "8mm – 348 Winchester" : {
+    "name" : "8mm – 348 Winchester",
+    "names" : [ "8 mm – 348 Win." ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page43.pdf" ],
+    "diameter_mm" : 8.22,
+    "diameter_inch" : 0.323622222
+  },
+  "9 x 53 R" : {
+    "name" : "9 x 53 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 67.0,
+      "coal_inch" : 2.6377967
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page47.pdf" ],
+    "diameter_mm" : 9.27,
+    "diameter_inch" : 0.364960827
+  },
+  "9 x 56 Mannlicher–Schönauer" : {
+    "name" : "9 x 56 Mannlicher–Schönauer",
+    "names" : [ "9 x 56 M.-Sch." ],
+    "specs" : {
+      "coal_mm" : 81.0,
+      "coal_inch" : 3.1889781
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page66.pdf" ],
+    "diameter_mm" : 9.08,
+    "diameter_inch" : 0.357480508
+  },
+  "9 x 57" : {
+    "name" : "9 x 57",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 81.0,
+      "coal_inch" : 3.1889781
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page67.pdf" ],
+    "diameter_mm" : 9.08,
+    "diameter_inch" : 0.357480508
+  },
+  "9 x 57 R" : {
+    "name" : "9 x 57 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 81.0,
+      "coal_inch" : 3.1889781
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page48.pdf" ],
+    "diameter_mm" : 9.08,
+    "diameter_inch" : 0.357480508
+  },
+  "9.3 Roedale Short Magnum" : {
+    "name" : "9.3 Roedale Short Magnum",
+    "names" : [ "9.3 RSM" ],
+    "specs" : {
+      "coal_mm" : 75.0,
+      "coal_inch" : 2.9527574999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/9-3-rsm-en.pdf" ],
+    "diameter_mm" : 9.3,
+    "diameter_inch" : 0.36614193
+  },
+  "9.3 x 53 R Finnish" : {
+    "name" : "9.3 x 53 R Finnish",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 76.0,
+      "coal_inch" : 2.9921276
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page49.pdf" ],
+    "diameter_mm" : 9.3,
+    "diameter_inch" : 0.36614193
+  },
+  "9.3 x 57" : {
+    "name" : "9.3 x 57",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 82.0,
+      "coal_inch" : 3.2283481999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/9-3-x-57-en.pdf" ],
+    "diameter_mm" : 9.3,
+    "diameter_inch" : 0.36614193
+  },
+  "9.3 x 62" : {
+    "name" : "9.3 x 62",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 83.6,
+      "coal_inch" : 3.2913403599999995
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page69.pdf" ],
+    "diameter_mm" : 9.3,
+    "diameter_inch" : 0.36614193
+  },
+  "9.3 x 64 Brenneke" : {
+    "name" : "9.3 x 64 Brenneke",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 85.6,
+      "coal_inch" : 3.3700805599999994
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page70.pdf" ],
+    "diameter_mm" : 9.3,
+    "diameter_inch" : 0.36614193
+  },
+  "9.3 x 66 Sako" : {
+    "name" : "9.3 x 66 Sako",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 85.0,
+      "coal_inch" : 3.3464585
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page71.pdf" ],
+    "diameter_mm" : 9.3,
+    "diameter_inch" : 0.36614193
+  },
+  "9.3 x 72 R" : {
+    "name" : "9.3 x 72 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 86.0,
+      "coal_inch" : 3.3858286
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page50.pdf" ],
+    "diameter_mm" : 9.57,
+    "diameter_inch" : 0.376771857
+  },
+  "9.3 x 74 R" : {
+    "name" : "9.3 x 74 R",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 96.5,
+      "coal_inch" : 3.7992146499999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/9-3-x-74-r-en.pdf" ],
+    "diameter_mm" : 9.3,
+    "diameter_inch" : 0.36614193
+  },
+  "9.5 x 57 Mannlicher–Schönauer" : {
+    "name" : "9.5 x 57 Mannlicher–Schönauer",
+    "names" : [ "9.5 x 57 M.-Sch." ],
+    "specs" : {
+      "coal_mm" : 75.0,
+      "coal_inch" : 2.9527574999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page72.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  },
+  "9.5 x 66 Super Express Vom Hofe" : {
+    "name" : "9.5 x 66 Super Express Vom Hofe",
+    "names" : [ "9.5 x 66 SE v. H." ],
+    "specs" : {
+      "coal_mm" : 85.0,
+      "coal_inch" : 3.3464585
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page73.pdf" ],
+    "diameter_mm" : 9.55,
+    "diameter_inch" : 0.375984455
+  }
 }

--- a/data/rifle/cip.json
+++ b/data/rifle/cip.json
@@ -3,2750 +3,2292 @@
     "name" : "10.3 CSP",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 72.7,
-      "coal_inch" : 2.86220627
+      "coal_mm" : "72.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/10-3-csp-en.pdf" ],
-    "diameter_mm" : 10.54,
-    "diameter_inch" : 0.41496085399999993
+    "diameter_mm" : "10.54"
   },
   "10.3 x 60 R" : {
     "name" : "10.3 x 60 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.9,
-      "coal_inch" : 3.10630089
+      "coal_mm" : "78.9"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page52.pdf" ],
-    "diameter_mm" : 10.54,
-    "diameter_inch" : 0.41496085399999993
+    "diameter_mm" : "10.54"
   },
   "10.75 x 68" : {
     "name" : "10.75 x 68",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 81.0,
-      "coal_inch" : 3.1889781
+      "coal_mm" : "81.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page74.pdf" ],
-    "diameter_mm" : 10.78,
-    "diameter_inch" : 0.42440967799999996
+    "diameter_mm" : "10.78"
   },
   "11.15 x 60 R" : {
     "name" : "11.15 x 60 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.0,
-      "coal_inch" : 3.0708678
+      "coal_mm" : "78.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page53.pdf" ],
-    "diameter_mm" : 11.4,
-    "diameter_inch" : 0.44881914
+    "diameter_mm" : "11.4"
   },
   "11.5 x 51" : {
     "name" : "11.5 x 51",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 62.0,
-      "coal_inch" : 2.4409462
+      "coal_mm" : "62.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page7.pdf" ],
-    "diameter_mm" : 11.49,
-    "diameter_inch" : 0.452362449
+    "diameter_mm" : "11.49"
   },
   "12.7 x 108" : {
     "name" : "12.7 x 108",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 147.0,
-      "coal_inch" : 5.7874047
+      "coal_mm" : "147.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/12-7-x-108-170419-en.pdf" ],
-    "diameter_mm" : 13.01,
-    "diameter_inch" : 0.512205001
+    "diameter_mm" : "13.01"
   },
   "12.7 x 70 (500 Schüler)" : {
     "name" : "12.7 x 70 (500 Schüler)",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 88.0,
-      "coal_inch" : 3.4645688
+      "coal_mm" : "88.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page75.pdf" ],
-    "diameter_mm" : 12.96,
-    "diameter_inch" : 0.510236496
+    "diameter_mm" : "12.96"
   },
   "17 Hornet" : {
     "name" : "17 Hornet",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 43.69,
-      "coal_inch" : 1.7200796689999998
+      "coal_mm" : "43.69"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/17-hornet-en.pdf" ],
-    "diameter_mm" : 4.38,
-    "diameter_inch" : 0.172441038
+    "diameter_mm" : "4.38"
   },
   "17 Libra" : {
     "name" : "17 Libra",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 41.0,
-      "coal_inch" : 1.6141740999999998
+      "coal_mm" : "41.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page76.pdf" ],
-    "diameter_mm" : 4.28,
-    "diameter_inch" : 0.168504028
+    "diameter_mm" : "4.28"
   },
   "17 Remington" : {
     "name" : "17 Remington",
     "names" : [ "17 Rem." ],
     "specs" : {
-      "coal_mm" : 54.61,
-      "coal_inch" : 2.150001161
+      "coal_mm" : "54.61"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page77.pdf" ],
-    "diameter_mm" : 4.38,
-    "diameter_inch" : 0.172441038
+    "diameter_mm" : "4.38"
   },
   "17 Remington Fireball" : {
     "name" : "17 Remington Fireball",
     "names" : [ "17 Rem. Fireball" ],
     "specs" : {
-      "coal_mm" : 46.48,
-      "coal_inch" : 1.8299222479999997
+      "coal_mm" : "46.48"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/17-rem-fireball-en.pdf" ],
-    "diameter_mm" : 4.38,
-    "diameter_inch" : 0.172441038
+    "diameter_mm" : "4.38"
   },
   "204 Ruger" : {
     "name" : "204 Ruger",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 57.4,
-      "coal_inch" : 2.25984374
+      "coal_mm" : "57.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page79.pdf" ],
-    "diameter_mm" : 5.19,
-    "diameter_inch" : 0.204330819
+    "diameter_mm" : "5.19"
   },
   "215" : {
     "name" : "215",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 58.0,
-      "coal_inch" : 2.2834658
+      "coal_mm" : "58.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/215-en.pdf" ],
-    "diameter_mm" : 5.64,
-    "diameter_inch" : 0.22204736399999997
+    "diameter_mm" : "5.64"
   },
   "218 Bee" : {
     "name" : "218 Bee",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 42.67,
-      "coal_inch" : 1.679922167
+      "coal_mm" : "42.67"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page54.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "219 Zipper" : {
     "name" : "219 Zipper",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 57.4,
-      "coal_inch" : 2.25984374
+      "coal_mm" : "57.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page55.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "22 Hornet" : {
     "name" : "22 Hornet",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 43.76,
-      "coal_inch" : 1.7228355759999998
+      "coal_mm" : "43.76"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page56.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "22 Palmisano & Pindel Cartridge-USA" : {
     "name" : "22 Palmisano & Pindel Cartridge-USA",
     "names" : [ "22 PPC-USA" ],
     "specs" : {
-      "coal_mm" : 55.7,
-      "coal_inch" : 2.19291457
+      "coal_mm" : "55.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page81.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "22 Savage" : {
     "name" : "22 Savage",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 63.75,
-      "coal_inch" : 2.509843875
+      "coal_mm" : "63.75"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page57.pdf" ],
-    "diameter_mm" : 5.79,
-    "diameter_inch" : 0.227952879
+    "diameter_mm" : "5.79"
   },
   "22-250 Remington" : {
     "name" : "22-250 Remington",
     "names" : [ "22-250 Rem." ],
     "specs" : {
-      "coal_mm" : 59.69,
-      "coal_inch" : 2.350001269
+      "coal_mm" : "59.69"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page82.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "220 Swift" : {
     "name" : "220 Swift",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 68.07,
-      "coal_inch" : 2.679922707
+      "coal_mm" : "68.07"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page83.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "222 R Stief" : {
     "name" : "222 R Stief",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 54.1,
-      "coal_inch" : 2.12992241
+      "coal_mm" : "54.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/222-r-stief-en.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "222 Remington" : {
     "name" : "222 Remington",
     "names" : [ "222 Rem." ],
     "specs" : {
-      "coal_mm" : 54.1,
-      "coal_inch" : 2.12992241
+      "coal_mm" : "54.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page84.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "222 Remington Magnum" : {
     "name" : "222 Remington Magnum",
     "names" : [ "222 Rem.Mag." ],
     "specs" : {
-      "coal_mm" : 57.91,
-      "coal_inch" : 2.2799224909999998
+      "coal_mm" : "57.91"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page85.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "223 Remington" : {
     "name" : "223 Remington",
     "names" : [ "223 Rem." ],
     "specs" : {
-      "coal_mm" : 57.4,
-      "coal_inch" : 2.25984374
+      "coal_mm" : "57.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/223-rem-170406-en.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "223 Winchester Super Short Magnum" : {
     "name" : "223 Winchester Super Short Magnum",
     "names" : [ "223 Win. SS Mag." ],
     "specs" : {
-      "coal_mm" : 59.94,
-      "coal_inch" : 2.3598437939999997
+      "coal_mm" : "59.94"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page87.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "224 Weatherby Magnum" : {
     "name" : "224 Weatherby Magnum",
     "names" : [ "224 Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 59.18,
-      "coal_inch" : 2.329922518
+      "coal_mm" : "59.18"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page8.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "225 Winchester" : {
     "name" : "225 Winchester",
     "names" : [ "225 Win." ],
     "specs" : {
-      "coal_mm" : 63.5,
-      "coal_inch" : 2.50000135
+      "coal_mm" : "63.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/225-win-en.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "240 Belted Rimless Nitro Express" : {
     "name" : "240 Belted Rimless Nitro Express",
     "names" : [ "240 Belt. Riml. N.E." ],
     "specs" : {
-      "coal_mm" : 82.55,
-      "coal_inch" : 3.2500017549999995
+      "coal_mm" : "82.55"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page9.pdf" ],
-    "diameter_mm" : 6.22,
-    "diameter_inch" : 0.24488202199999998
+    "diameter_mm" : "6.22"
   },
   "240 Flanged Nitro Express" : {
     "name" : "240 Flanged Nitro Express",
     "names" : [ "240 Fl. N.E." ],
     "specs" : {
-      "coal_mm" : 82.55,
-      "coal_inch" : 3.2500017549999995
+      "coal_mm" : "82.55"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page59.pdf" ],
-    "diameter_mm" : 6.22,
-    "diameter_inch" : 0.24488202199999998
+    "diameter_mm" : "6.22"
   },
   "240 Weatherby Magnum" : {
     "name" : "240 Weatherby Magnum",
     "names" : [ "240 Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 78.74,
-      "coal_inch" : 3.1000016739999996
+      "coal_mm" : "78.74"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page10.pdf" ],
-    "diameter_mm" : 6.18,
-    "diameter_inch" : 0.24330721799999996
+    "diameter_mm" : "6.18"
   },
   "243 Winchester" : {
     "name" : "243 Winchester",
     "names" : [ "243 Win." ],
     "specs" : {
-      "coal_mm" : 68.83,
-      "coal_inch" : 2.709843983
+      "coal_mm" : "68.83"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page88.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "243 Winchester Super Short Magnum" : {
     "name" : "243 Winchester Super Short Magnum",
     "names" : [ "243 Win. SS Mag." ],
     "specs" : {
-      "coal_mm" : 59.94,
-      "coal_inch" : 2.3598437939999997
+      "coal_mm" : "59.94"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page89.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "244 Holland & Holland Magnum" : {
     "name" : "244 Holland & Holland Magnum",
     "names" : [ "244 H&H Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page11.pdf" ],
-    "diameter_mm" : 6.22,
-    "diameter_inch" : 0.24488202199999998
+    "diameter_mm" : "6.22"
   },
   "25 Remington" : {
     "name" : "25 Remington",
     "names" : [ "25 Rem." ],
     "specs" : {
-      "coal_mm" : 64.14,
-      "coal_inch" : 2.525198214
+      "coal_mm" : "64.14"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page90.pdf" ],
-    "diameter_mm" : 6.58,
-    "diameter_inch" : 0.259055258
+    "diameter_mm" : "6.58"
   },
   "25 Winchester SSM" : {
     "name" : "25 Winchester SSM",
     "names" : [ "25 Win. SSM" ],
     "specs" : {
-      "coal_mm" : 59.94,
-      "coal_inch" : 2.3598437939999997
+      "coal_mm" : "59.94"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/25-win-super-short-mag-en.pdf" ],
-    "diameter_mm" : 6.54,
-    "diameter_inch" : 0.25748045399999997
+    "diameter_mm" : "6.54"
   },
   "25-06 Remington" : {
     "name" : "25-06 Remington",
     "names" : [ "25-06 Rem." ],
     "specs" : {
-      "coal_mm" : 82.55,
-      "coal_inch" : 3.2500017549999995
+      "coal_mm" : "82.55"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page92.pdf" ],
-    "diameter_mm" : 6.54,
-    "diameter_inch" : 0.25748045399999997
+    "diameter_mm" : "6.54"
   },
   "25-20 Winchester" : {
     "name" : "25-20 Winchester",
     "names" : [ "25-20 Win." ],
     "specs" : {
-      "coal_mm" : 40.44,
-      "coal_inch" : 1.5921268439999998
+      "coal_mm" : "40.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page60.pdf" ],
-    "diameter_mm" : 6.55,
-    "diameter_inch" : 0.257874155
+    "diameter_mm" : "6.55"
   },
   "25-35 Winchester" : {
     "name" : "25-35 Winchester",
     "names" : [ "25-35 Win." ],
     "specs" : {
-      "coal_mm" : 64.77,
-      "coal_inch" : 2.5500013769999996
+      "coal_mm" : "64.77"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page61.pdf" ],
-    "diameter_mm" : 6.55,
-    "diameter_inch" : 0.257874155
+    "diameter_mm" : "6.55"
   },
   "250 Savage" : {
     "name" : "250 Savage",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 63.88,
-      "coal_inch" : 2.514961988
+      "coal_mm" : "63.88"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page93.pdf" ],
-    "diameter_mm" : 6.55,
-    "diameter_inch" : 0.257874155
+    "diameter_mm" : "6.55"
   },
   "255 Giani Special" : {
     "name" : "255 Giani Special",
     "names" : [ "255 GS" ],
     "specs" : {
-      "coal_mm" : 72.5,
-      "coal_inch" : 2.8543322499999997
+      "coal_mm" : "72.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page94.pdf" ],
-    "diameter_mm" : 6.54,
-    "diameter_inch" : 0.25748045399999997
+    "diameter_mm" : "6.54"
   },
   "256 Magnum Gibbs" : {
     "name" : "256 Magnum Gibbs",
     "names" : [ "256 Mag. Gibbs" ],
     "specs" : {
-      "coal_mm" : 77.47,
-      "coal_inch" : 3.0500016469999998
+      "coal_mm" : "77.47"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page95.pdf" ],
-    "diameter_mm" : 6.73,
-    "diameter_inch" : 0.264960773
+    "diameter_mm" : "6.73"
   },
   "256 Winchester Magnum" : {
     "name" : "256 Winchester Magnum",
     "names" : [ "256 Win. Mag." ],
     "specs" : {
-      "coal_mm" : 40.39,
-      "coal_inch" : 1.590158339
+      "coal_mm" : "40.39"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/256-win-mag-en.pdf" ],
-    "diameter_mm" : 6.53,
-    "diameter_inch" : 0.257086753
+    "diameter_mm" : "6.53"
   },
   "257 Roberts" : {
     "name" : "257 Roberts",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 70.49,
-      "coal_inch" : 2.7751983489999996
+      "coal_mm" : "70.49"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page96.pdf" ],
-    "diameter_mm" : 6.55,
-    "diameter_inch" : 0.257874155
+    "diameter_mm" : "6.55"
   },
   "257 Weatherby Magnum" : {
     "name" : "257 Weatherby Magnum",
     "names" : [ "257 Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 80.52,
-      "coal_inch" : 3.1700804519999997
+      "coal_mm" : "80.52"
     },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page12.pdf" ],
-    "diameter_mm" : 6.54,
-    "diameter_inch" : 0.25748045399999997
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/257-weath-mag-180803-en.pdf" ],
+    "diameter_mm" : "6.54"
   },
   "260 Remington" : {
     "name" : "260 Remington",
     "names" : [ "260 Rem." ],
     "specs" : {
-      "coal_mm" : 71.12,
-      "coal_inch" : 2.800001512
+      "coal_mm" : "71.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page97.pdf" ],
-    "diameter_mm" : 6.72,
-    "diameter_inch" : 0.26456707199999996
+    "diameter_mm" : "6.72"
   },
   "264 Leroy Nitro Express" : {
     "name" : "264 Leroy Nitro Express",
     "names" : [ "264 Leroy N.E." ],
     "specs" : {
-      "coal_mm" : 65.0,
-      "coal_inch" : 2.5590565
+      "coal_mm" : "65.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page98.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "264 Winchester Magnum" : {
     "name" : "264 Winchester Magnum",
     "names" : [ "264 Win. Mag." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page13.pdf" ],
-    "diameter_mm" : 6.73,
-    "diameter_inch" : 0.264960773
+    "diameter_mm" : "6.73"
   },
   "270 Weatherby Magnum" : {
     "name" : "270 Weatherby Magnum",
     "names" : [ "270 Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 83.69,
-      "coal_inch" : 3.294883669
+      "coal_mm" : "83.69"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page14.pdf" ],
-    "diameter_mm" : 7.04,
-    "diameter_inch" : 0.277165504
+    "diameter_mm" : "7.04"
   },
   "270 Winchester" : {
     "name" : "270 Winchester",
     "names" : [ "270 Win." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page99.pdf" ],
-    "diameter_mm" : 7.06,
-    "diameter_inch" : 0.27795290599999994
+    "diameter_mm" : "7.06"
   },
   "270 Winchester Short Magnum" : {
     "name" : "270 Winchester Short Magnum",
     "names" : [ "270 Win. Short Mag." ],
     "specs" : {
-      "coal_mm" : 72.64,
-      "coal_inch" : 2.859844064
+      "coal_mm" : "72.64"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page100.pdf" ],
-    "diameter_mm" : 7.06,
-    "diameter_inch" : 0.27795290599999994
+    "diameter_mm" : "7.06"
   },
   "275 Belted Nitro Express" : {
     "name" : "275 Belted Nitro Express",
     "names" : [ "275 Belt. N.E." ],
     "specs" : {
-      "coal_mm" : 87.12,
-      "coal_inch" : 3.429923112
+      "coal_mm" : "87.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page15.pdf" ],
-    "diameter_mm" : 7.29,
-    "diameter_inch" : 0.287008029
+    "diameter_mm" : "7.29"
   },
   "275 H.V. Rigby" : {
     "name" : "275 H.V. Rigby",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 77.98,
-      "coal_inch" : 3.070080398
+      "coal_mm" : "77.98"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page101.pdf" ],
-    "diameter_mm" : 7.21,
-    "diameter_inch" : 0.28385842099999997
+    "diameter_mm" : "7.21"
   },
   "277 Giani Special" : {
     "name" : "277 Giani Special",
     "names" : [ "277 GS" ],
     "specs" : {
-      "coal_mm" : 87.0,
-      "coal_inch" : 3.4251986999999997
+      "coal_mm" : "87.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/277-gs-en.pdf" ],
-    "diameter_mm" : 7.06,
-    "diameter_inch" : 0.27795290599999994
+    "diameter_mm" : "7.06"
   },
   "280 Flanged Nitro Express" : {
     "name" : "280 Flanged Nitro Express",
     "names" : [ "280 Fl. N.E." ],
     "specs" : {
-      "coal_mm" : 87.88,
-      "coal_inch" : 3.4598443879999996
+      "coal_mm" : "87.88"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page63.pdf" ],
-    "diameter_mm" : 7.29,
-    "diameter_inch" : 0.287008029
+    "diameter_mm" : "7.29"
   },
   "280 Remington" : {
     "name" : "280 Remington",
     "names" : [ "280 Rem." ],
     "specs" : {
-      "coal_mm" : 84.58,
-      "coal_inch" : 3.329923058
+      "coal_mm" : "84.58"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page103.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "280 Rimless Nitro Express Ross" : {
     "name" : "280 Rimless Nitro Express Ross",
     "names" : [ "280 Riml. N.E. Ross" ],
     "specs" : {
-      "coal_mm" : 87.88,
-      "coal_inch" : 3.4598443879999996
+      "coal_mm" : "87.88"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page104.pdf" ],
-    "diameter_mm" : 7.29,
-    "diameter_inch" : 0.287008029
+    "diameter_mm" : "7.29"
   },
   "284 Tony" : {
     "name" : "284 Tony",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.0,
-      "coal_inch" : 3.0708678
+      "coal_mm" : "78.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/284-tony-en.pdf" ],
-    "diameter_mm" : 7.21,
-    "diameter_inch" : 0.28385842099999997
+    "diameter_mm" : "7.21"
   },
   "284 Winchester" : {
     "name" : "284 Winchester",
     "names" : [ "284 Win." ],
     "specs" : {
-      "coal_mm" : 71.12,
-      "coal_inch" : 2.800001512
+      "coal_mm" : "71.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page105.pdf" ],
-    "diameter_mm" : 7.21,
-    "diameter_inch" : 0.28385842099999997
+    "diameter_mm" : "7.21"
   },
   "297/230 Morris Long" : {
     "name" : "297/230 Morris Long",
     "names" : [ "297/230 Morris lg" ],
     "specs" : {
-      "coal_mm" : 27.43,
-      "coal_inch" : 1.079921843
+      "coal_mm" : "27.43"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page64.pdf" ],
-    "diameter_mm" : 5.71,
-    "diameter_inch" : 0.224803271
+    "diameter_mm" : "5.71"
   },
   "297/230 Morris sh" : {
     "name" : "297/230 Morris sh",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 22.61,
-      "coal_inch" : 0.8901579609999999
+      "coal_mm" : "22.61"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page65.pdf" ],
-    "diameter_mm" : 5.71,
-    "diameter_inch" : 0.224803271
+    "diameter_mm" : "5.71"
   },
   "30 BR" : {
     "name" : "30 BR",
     "names" : [ "30 Bench Rest" ],
     "specs" : {
-      "coal_mm" : 58.0,
-      "coal_inch" : 2.2834658
+      "coal_mm" : "58.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/30-br-en.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "30 Carbine" : {
     "name" : "30 Carbine",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 42.67,
-      "coal_inch" : 1.679922167
+      "coal_mm" : "42.67"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page106.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30 Court" : {
     "name" : "30 Court",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 41.35,
-      "coal_inch" : 1.627953635
+      "coal_mm" : "41.35"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page107.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30 Flanged Nitro Express Purdey" : {
     "name" : "30 Flanged Nitro Express Purdey",
     "names" : [ "30 Fl. N.E. Purdey" ],
     "specs" : {
-      "coal_mm" : 75.69,
-      "coal_inch" : 2.9799228689999997
+      "coal_mm" : "75.69"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/30-fi-ne-purdey-en.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "30 R Blaser" : {
     "name" : "30 R Blaser",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 95.0,
-      "coal_inch" : 3.7401595
+      "coal_mm" : "95.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page66.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30 Remington" : {
     "name" : "30 Remington",
     "names" : [ "30 Rem." ],
     "specs" : {
-      "coal_mm" : 64.14,
-      "coal_inch" : 2.525198214
+      "coal_mm" : "64.14"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page108.pdf" ],
-    "diameter_mm" : 7.8,
-    "diameter_inch" : 0.30708678
+    "diameter_mm" : "7.8"
   },
   "30 Super Belted Rimless Holland & Holland" : {
     "name" : "30 Super Belted Rimless Holland & Holland",
     "names" : [ "30 Super Bl Riml. H&H" ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page16.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "30 Super Flanged Holland & Holland" : {
     "name" : "30 Super Flanged Holland & Holland",
     "names" : [ "300 Fl. N.E.", "30 Super Fl. H&H" ],
     "specs" : {
-      "coal_mm" : 93.73,
-      "coal_inch" : 3.690159473
+      "coal_mm" : "93.73"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/30-super-fi-h-h-en.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "30 TC" : {
     "name" : "30 TC",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 67.56,
-      "coal_inch" : 2.659843956
+      "coal_mm" : "67.56"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page109.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-06 Ackley Improved" : {
     "name" : "30-06 Ackley Improved",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/30-06-ackley-improved-en.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-06 Court Cartry" : {
     "name" : "30-06 Court Cartry",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.3,
-      "coal_inch" : 3.2401592299999997
+      "coal_mm" : "82.3"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page110.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-06 R Stief" : {
     "name" : "30-06 R Stief",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page69.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-06 Springfield" : {
     "name" : "30-06 Springfield",
     "names" : [ "30-06", "7,62 x 63", "30-06 Spring." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page111.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-284 NOLASCO" : {
     "name" : "30-284 NOLASCO",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 76.0,
-      "coal_inch" : 2.9921276
+      "coal_mm" : "76.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page112.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-284 Winchester" : {
     "name" : "30-284 Winchester",
     "names" : [ "30-284 Win." ],
     "specs" : {
-      "coal_mm" : 72.0,
-      "coal_inch" : 2.8346472
+      "coal_mm" : "72.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page113.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-30 Winchester" : {
     "name" : "30-30 Winchester",
     "names" : [ "30-30 Win." ],
     "specs" : {
-      "coal_mm" : 64.77,
-      "coal_inch" : 2.5500013769999996
+      "coal_mm" : "64.77"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page70.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-338 Prechtl Magnum" : {
     "name" : "30-338 Prechtl Magnum",
     "names" : [ "30-338 Prechtl Mag." ],
     "specs" : {
-      "coal_mm" : 93.2,
-      "coal_inch" : 3.66929332
+      "coal_mm" : "93.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/30-338-prechtl-magnum-170310-en.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-378 Weatherby Magnum" : {
     "name" : "30-378 Weatherby Magnum",
     "names" : [ "30-378 Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 95.25,
-      "coal_inch" : 3.7500020249999997
+      "coal_mm" : "95.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page17.pdf" ],
-    "diameter_mm" : 7.83,
-    "diameter_inch" : 0.30826788299999996
+    "diameter_mm" : "7.83"
   },
   "30-40 Krag" : {
     "name" : "30-40 Krag",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.46,
-      "coal_inch" : 3.088978046
+      "coal_mm" : "78.46"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/30-40-krag-en.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "30-47 Giani Special" : {
     "name" : "30-47 Giani Special",
     "names" : [ "30-47 GS" ],
     "specs" : {
-      "coal_mm" : 66.6,
-      "coal_inch" : 2.6220486599999995
+      "coal_mm" : "66.6"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/30-47-gs-en.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "300 Advanced Armament Corporation Blackout" : {
     "name" : "300 Advanced Armament Corporation Blackout",
     "names" : [ "300 Whisper", "300 BLK", "7,62 x 35", "300 AAC Blackout" ],
     "specs" : {
-      "coal_mm" : 57.4,
-      "coal_inch" : 2.25984374
+      "coal_mm" : "57.4"
     },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-aac-blacout-170307-en.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-aac-blackout-180801-en.pdf" ],
+    "diameter_mm" : "7.85"
   },
   "300 Blacktornado" : {
     "name" : "300 Blacktornado",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.0,
-      "coal_inch" : 3.3070884
+      "coal_mm" : "84.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-blacktornado-en.pdf" ],
-    "diameter_mm" : 7.83,
-    "diameter_inch" : 0.30826788299999996
+    "diameter_mm" : "7.83"
   },
   "300 Blaser Magnum" : {
     "name" : "300 Blaser Magnum",
     "names" : [ "300 Blaser Mag." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page114.pdf" ],
-    "diameter_mm" : 7.83,
-    "diameter_inch" : 0.30826788299999996
+    "diameter_mm" : "7.83"
   },
   "300 CR" : {
     "name" : "300 CR",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 71.0,
-      "coal_inch" : 2.7952771
+      "coal_mm" : "71.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page115.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "300 Holland & Holland Magnum" : {
     "name" : "300 Holland & Holland Magnum",
     "names" : [ "30 Super Belt. Riml. H&H", "300 H&H Belt. Riml. N.E.", "300 H&H Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/300-h-h-mag-en.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "300 Lapua Magnum" : {
     "name" : "300 Lapua Magnum",
     "names" : [ "300 Lapua Mag." ],
     "specs" : {
-      "coal_mm" : 94.5,
-      "coal_inch" : 3.7204744499999998
+      "coal_mm" : "94.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page116.pdf" ],
-    "diameter_mm" : 7.87,
-    "diameter_inch" : 0.309842687
+    "diameter_mm" : "7.87"
   },
   "300 Norma Magnum" : {
     "name" : "300 Norma Magnum",
     "names" : [ "300 Norma Mag" ],
     "specs" : {
-      "coal_mm" : 93.5,
-      "coal_inch" : 3.68110435
+      "coal_mm" : "93.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-norma-mag-en.pdf" ],
-    "diameter_mm" : 7.83,
-    "diameter_inch" : 0.30826788299999996
+    "diameter_mm" : "7.83"
   },
   "300 Pegasus" : {
     "name" : "300 Pegasus",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 95.25,
-      "coal_inch" : 3.7500020249999997
+      "coal_mm" : "95.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-pegasus-en.pdf" ],
-    "diameter_mm" : 7.82,
-    "diameter_inch" : 0.307874182
+    "diameter_mm" : "7.82"
   },
   "300 RCM" : {
     "name" : "300 RCM",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 72.14,
-      "coal_inch" : 2.8401590139999997
+      "coal_mm" : "72.14"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/300-rcm-en.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "300 Remington Short Action Ultra Magnum" : {
     "name" : "300 Remington Short Action Ultra Magnum",
     "names" : [ "300 Rem. SA Ultra Mag." ],
     "specs" : {
-      "coal_mm" : 71.76,
-      "coal_inch" : 2.825198376
+      "coal_mm" : "71.76"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page118.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "300 Remington Ultra Magnum" : {
     "name" : "300 Remington Ultra Magnum",
     "names" : [ "300 Rem. Ultra Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page119.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "300 Savage" : {
     "name" : "300 Savage",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 66.04,
-      "coal_inch" : 2.600001404
+      "coal_mm" : "66.04"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page120.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "300 Sherwood" : {
     "name" : "300 Sherwood",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 51.82,
-      "coal_inch" : 2.040158582
+      "coal_mm" : "51.82"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page73.pdf" ],
-    "diameter_mm" : 7.62,
-    "diameter_inch" : 0.300000162
+    "diameter_mm" : "7.62"
   },
   "300 Weatherby Magnum" : {
     "name" : "300 Weatherby Magnum",
     "names" : [ "300 Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 90.42,
-      "coal_inch" : 3.5598444419999997
+      "coal_mm" : "90.42"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page19.pdf" ],
-    "diameter_mm" : 7.83,
-    "diameter_inch" : 0.30826788299999996
+    "diameter_mm" : "7.83"
   },
   "300 Winchester Magnum" : {
     "name" : "300 Winchester Magnum",
     "names" : [ "300 Win. Mag." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page20.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "300 Winchester Short Magnum" : {
     "name" : "300 Winchester Short Magnum",
     "names" : [ "300 Win. Short Mag." ],
     "specs" : {
-      "coal_mm" : 72.64,
-      "coal_inch" : 2.859844064
+      "coal_mm" : "72.64"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page122.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "300/295 Rook Rifle" : {
     "name" : "300/295 Rook Rifle",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 36.83,
-      "coal_inch" : 1.450000783
+      "coal_mm" : "36.83"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/300-295-rook-rifle-en.pdf" ],
-    "diameter_mm" : 7.65,
-    "diameter_inch" : 0.301181265
+    "diameter_mm" : "7.65"
   },
   "303 British" : {
     "name" : "303 British",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.11,
-      "coal_inch" : 3.075198511
+      "coal_mm" : "78.11"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page74.pdf" ],
-    "diameter_mm" : 7.92,
-    "diameter_inch" : 0.31181119199999996
+    "diameter_mm" : "7.92"
   },
   "303 Savage" : {
     "name" : "303 Savage",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 64.01,
-      "coal_inch" : 2.520080101
+      "coal_mm" : "64.01"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/303-savage-en.pdf" ],
-    "diameter_mm" : 7.9,
-    "diameter_inch" : 0.31102379
+    "diameter_mm" : "7.9"
   },
   "303 Sporting" : {
     "name" : "303 Sporting",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 74.49,
-      "coal_inch" : 2.9326787489999995
+      "coal_mm" : "74.49"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page76.pdf" ],
-    "diameter_mm" : 7.92,
-    "diameter_inch" : 0.31181119199999996
+    "diameter_mm" : "7.92"
   },
   "307 Winchester" : {
     "name" : "307 Winchester",
     "names" : [ "307 Win." ],
     "specs" : {
-      "coal_mm" : 65.02,
-      "coal_inch" : 2.559843902
+      "coal_mm" : "65.02"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/307-win-en.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "308 EH" : {
     "name" : "308 EH",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 57.5,
-      "coal_inch" : 2.26378075
+      "coal_mm" : "57.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page123.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "308 Marlin Express" : {
     "name" : "308 Marlin Express",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 66.04,
-      "coal_inch" : 2.600001404
+      "coal_mm" : "66.04"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/308-marlin-express-en.pdf" ],
-    "diameter_mm" : 7.84,
-    "diameter_inch" : 0.308661584
+    "diameter_mm" : "7.84"
   },
   "308 Match" : {
     "name" : "308 Match",
     "names" : [ "308 GAC" ],
     "specs" : {
-      "coal_mm" : 71.12,
-      "coal_inch" : 2.800001512
+      "coal_mm" : "71.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/308-match-en.pdf" ],
-    "diameter_mm" : 7.84,
-    "diameter_inch" : 0.308661584
+    "diameter_mm" : "7.84"
   },
   "308 Norma Magnum" : {
     "name" : "308 Norma Magnum",
     "names" : [ "308 Norma Mag." ],
     "specs" : {
-      "coal_mm" : 85.0,
-      "coal_inch" : 3.3464585
+      "coal_mm" : "85.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/308-norma-mag-en.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "308 Winchester" : {
     "name" : "308 Winchester",
     "names" : [ "7,62 x 51", "308 Winchester", "308 Win." ],
     "specs" : {
-      "coal_mm" : 71.12,
-      "coal_inch" : 2.800001512
+      "coal_mm" : "71.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page125.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "310 Cadet Rifle" : {
     "name" : "310 Cadet Rifle",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 40.64,
-      "coal_inch" : 1.6000008639999999
+      "coal_mm" : "40.64"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page78.pdf" ],
-    "diameter_mm" : 8.2,
-    "diameter_inch" : 0.32283481999999997
+    "diameter_mm" : "8.2"
   },
   "318 Rimless Nitro Express" : {
     "name" : "318 Rimless Nitro Express",
     "names" : [ "318 Westley Richards", "318 Riml. N.E." ],
     "specs" : {
-      "coal_mm" : 89.66,
-      "coal_inch" : 3.5299231659999997
+      "coal_mm" : "89.66"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page126.pdf" ],
-    "diameter_mm" : 8.38,
-    "diameter_inch" : 0.329921438
+    "diameter_mm" : "8.38"
   },
   "32 Remington" : {
     "name" : "32 Remington",
     "names" : [ "32 Rem." ],
     "specs" : {
-      "coal_mm" : 64.14,
-      "coal_inch" : 2.525198214
+      "coal_mm" : "64.14"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page127.pdf" ],
-    "diameter_mm" : 8.15,
-    "diameter_inch" : 0.320866315
+    "diameter_mm" : "8.15"
   },
   "32 Winchester Self-loading" : {
     "name" : "32 Winchester Self-loading",
     "names" : [ "32 Win. SL" ],
     "specs" : {
-      "coal_mm" : 47.75,
-      "coal_inch" : 1.879922275
+      "coal_mm" : "47.75"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page79.pdf" ],
-    "diameter_mm" : 8.18,
-    "diameter_inch" : 0.322047418
+    "diameter_mm" : "8.18"
   },
   "32 Winchester Special" : {
     "name" : "32 Winchester Special",
     "names" : [ "32 Win. Spec." ],
     "specs" : {
-      "coal_mm" : 65.15,
-      "coal_inch" : 2.5649620150000003
+      "coal_mm" : "65.15"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page80.pdf" ],
-    "diameter_mm" : 8.18,
-    "diameter_inch" : 0.322047418
+    "diameter_mm" : "8.18"
   },
   "32-20 Winchester" : {
     "name" : "32-20 Winchester",
     "names" : [ "32-20 Win." ],
     "specs" : {
-      "coal_mm" : 40.44,
-      "coal_inch" : 1.5921268439999998
+      "coal_mm" : "40.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page81.pdf" ],
-    "diameter_mm" : 7.94,
-    "diameter_inch" : 0.312598594
+    "diameter_mm" : "7.94"
   },
   "32-40 Winchester" : {
     "name" : "32-40 Winchester",
     "names" : [ "32-40 Win." ],
     "specs" : {
-      "coal_mm" : 63.5,
-      "coal_inch" : 2.50000135
+      "coal_mm" : "63.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page82.pdf" ],
-    "diameter_mm" : 8.15,
-    "diameter_inch" : 0.320866315
+    "diameter_mm" : "8.15"
   },
   "325 Winchester Short Magnum" : {
     "name" : "325 Winchester Short Magnum",
     "names" : [ "325 WSM" ],
     "specs" : {
-      "coal_mm" : 72.64,
-      "coal_inch" : 2.859844064
+      "coal_mm" : "72.64"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page128.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "33 Winchester" : {
     "name" : "33 Winchester",
     "names" : [ "33 Win." ],
     "specs" : {
-      "coal_mm" : 70.99,
-      "coal_inch" : 2.7948833989999997
+      "coal_mm" : "70.99"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page83.pdf" ],
-    "diameter_mm" : 8.6,
-    "diameter_inch" : 0.33858286
+    "diameter_mm" : "8.6"
   },
   "333 Rimless Nitro Express" : {
     "name" : "333 Rimless Nitro Express",
     "names" : [ "333 Riml. N.E." ],
     "specs" : {
-      "coal_mm" : 88.9,
-      "coal_inch" : 3.50000189
+      "coal_mm" : "88.9"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page129.pdf" ],
-    "diameter_mm" : 8.46,
-    "diameter_inch" : 0.33307104600000004
+    "diameter_mm" : "8.46"
   },
   "338 Blaser Magnum" : {
     "name" : "338 Blaser Magnum",
     "names" : [ "338 Blaser Mag." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page130.pdf" ],
-    "diameter_mm" : 8.59,
-    "diameter_inch" : 0.33818915899999996
+    "diameter_mm" : "8.59"
   },
   "338 Federal" : {
     "name" : "338 Federal",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 71.63,
-      "coal_inch" : 2.8200802629999995
+      "coal_mm" : "71.63"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/338-federal-en.pdf" ],
-    "diameter_mm" : 8.61,
-    "diameter_inch" : 0.33897656099999995
+    "diameter_mm" : "8.61"
   },
   "338 Lapua Magnum" : {
     "name" : "338 Lapua Magnum",
     "names" : [ "8,6 (mm) x 70", "338 Lapua Mag." ],
     "specs" : {
-      "coal_mm" : 93.5,
-      "coal_inch" : 3.68110435
+      "coal_mm" : "93.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/338-lapua-mag-en.pdf" ],
-    "diameter_mm" : 8.61,
-    "diameter_inch" : 0.33897656099999995
+    "diameter_mm" : "8.61"
   },
   "338 Marlin Express" : {
     "name" : "338 Marlin Express",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 62.23,
-      "coal_inch" : 2.450001323
+      "coal_mm" : "62.23"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page84.pdf" ],
-    "diameter_mm" : 8.6,
-    "diameter_inch" : 0.33858286
+    "diameter_mm" : "8.6"
   },
   "338 Norma Magnum" : {
     "name" : "338 Norma Magnum",
     "names" : [ "338 Norma Mag." ],
     "specs" : {
-      "coal_mm" : 93.5,
-      "coal_inch" : 3.68110435
+      "coal_mm" : "93.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page133.pdf" ],
-    "diameter_mm" : 8.6,
-    "diameter_inch" : 0.33858286
+    "diameter_mm" : "8.6"
   },
   "338 RCM" : {
     "name" : "338 RCM",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 72.14,
-      "coal_inch" : 2.8401590139999997
+      "coal_mm" : "72.14"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/338-rcm-en.pdf" ],
-    "diameter_mm" : 8.61,
-    "diameter_inch" : 0.33897656099999995
+    "diameter_mm" : "8.61"
   },
   "338 Remington Ultra Magnum" : {
     "name" : "338 Remington Ultra Magnum",
     "names" : [ "338 Rem. Ultra Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page134.pdf" ],
-    "diameter_mm" : 8.6,
-    "diameter_inch" : 0.33858286
+    "diameter_mm" : "8.6"
   },
   "338 Winchester Magnum" : {
     "name" : "338 Winchester Magnum",
     "names" : [ "338 Win. Mag." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page22.pdf" ],
-    "diameter_mm" : 8.61,
-    "diameter_inch" : 0.33897656099999995
+    "diameter_mm" : "8.61"
   },
   "338 Winchester Short Magnum" : {
     "name" : "338 Winchester Short Magnum",
     "names" : [ "338 Win. Short Mag." ],
     "specs" : {
-      "coal_mm" : 69.78,
-      "coal_inch" : 2.747245578
+      "coal_mm" : "69.78"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page135.pdf" ],
-    "diameter_mm" : 8.69,
-    "diameter_inch" : 0.342126169
+    "diameter_mm" : "8.69"
   },
   "338-378 Weatherby Mag" : {
     "name" : "338-378 Weatherby Mag",
     "names" : [ "338-378 Weath. Mag" ],
     "specs" : {
-      "coal_mm" : 95.58,
-      "coal_inch" : 3.7629941579999997
+      "coal_mm" : "95.58"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page23.pdf" ],
-    "diameter_mm" : 8.6,
-    "diameter_inch" : 0.33858286
+    "diameter_mm" : "8.6"
   },
   "340 Weatherby Magnum" : {
     "name" : "340 Weatherby Magnum",
     "names" : [ "340 Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 93.35,
-      "coal_inch" : 3.6751988349999998
+      "coal_mm" : "93.35"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page24.pdf" ],
-    "diameter_mm" : 8.59,
-    "diameter_inch" : 0.33818915899999996
+    "diameter_mm" : "8.59"
   },
   "348 Winchester" : {
     "name" : "348 Winchester",
     "names" : [ "348 Win." ],
     "specs" : {
-      "coal_mm" : 70.99,
-      "coal_inch" : 2.7948833989999997
+      "coal_mm" : "70.99"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page85.pdf" ],
-    "diameter_mm" : 8.88,
-    "diameter_inch" : 0.349606488
+    "diameter_mm" : "8.88"
   },
   "35 Remington" : {
     "name" : "35 Remington",
     "names" : [ "35 Rem." ],
     "specs" : {
-      "coal_mm" : 64.14,
-      "coal_inch" : 2.525198214
+      "coal_mm" : "64.14"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page136.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "35 Whelen" : {
     "name" : "35 Whelen",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page137.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "35 Winchester" : {
     "name" : "35 Winchester",
     "names" : [ "35 Win." ],
     "specs" : {
-      "coal_mm" : 80.65,
-      "coal_inch" : 3.175198565
+      "coal_mm" : "80.65"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page86.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "35 Winchester Self-loading" : {
     "name" : "35 Winchester Self-loading",
     "names" : [ "35 Win. SL" ],
     "specs" : {
-      "coal_mm" : 41.91,
-      "coal_inch" : 1.6500008909999997
+      "coal_mm" : "41.91"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page87.pdf" ],
-    "diameter_mm" : 8.95,
-    "diameter_inch" : 0.35236239499999994
+    "diameter_mm" : "8.95"
   },
   "350 Magnum Rigby" : {
     "name" : "350 Magnum Rigby",
     "names" : [ "350 Mag. Rigby" ],
     "specs" : {
-      "coal_mm" : 90.8,
-      "coal_inch" : 3.5748050799999995
+      "coal_mm" : "90.8"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page138.pdf" ],
-    "diameter_mm" : 9.07,
-    "diameter_inch" : 0.357086807
+    "diameter_mm" : "9.07"
   },
   "350 No. 2 Rigby" : {
     "name" : "350 No. 2 Rigby",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 93.73,
-      "coal_inch" : 3.690159473
+      "coal_mm" : "93.73"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page88.pdf" ],
-    "diameter_mm" : 9.04,
-    "diameter_inch" : 0.35590570399999993
+    "diameter_mm" : "9.04"
   },
   "350 Remington Magnum" : {
     "name" : "350 Remington Magnum",
     "names" : [ "350 Rem.Mag." ],
     "specs" : {
-      "coal_mm" : 71.12,
-      "coal_inch" : 2.800001512
+      "coal_mm" : "71.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page25.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "351 Winchester Self-loading" : {
     "name" : "351 Winchester Self-loading",
     "names" : [ "351 Win. SL" ],
     "specs" : {
-      "coal_mm" : 48.26,
-      "coal_inch" : 1.9000010259999998
+      "coal_mm" : "48.26"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/351-win-sl-en.pdf" ],
-    "diameter_mm" : 8.94,
-    "diameter_inch" : 0.35196869399999997
+    "diameter_mm" : "8.94"
   },
   "356 Winchester" : {
     "name" : "356 Winchester",
     "names" : [ "356 Win." ],
     "specs" : {
-      "coal_mm" : 65.02,
-      "coal_inch" : 2.559843902
+      "coal_mm" : "65.02"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/356-win-en.pdf" ],
-    "diameter_mm" : 9.11,
-    "diameter_inch" : 0.35866161099999994
+    "diameter_mm" : "9.11"
   },
   "358 Norma Magnum" : {
     "name" : "358 Norma Magnum",
     "names" : [ "358 Norma Mag." ],
     "specs" : {
-      "coal_mm" : 85.0,
-      "coal_inch" : 3.3464585
+      "coal_mm" : "85.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page26.pdf" ],
-    "diameter_mm" : 9.12,
-    "diameter_inch" : 0.35905531199999996
+    "diameter_mm" : "9.12"
   },
   "358 Winchester" : {
     "name" : "358 Winchester",
     "names" : [ "358 Win." ],
     "specs" : {
-      "coal_mm" : 70.61,
-      "coal_inch" : 2.779922761
+      "coal_mm" : "70.61"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page139.pdf" ],
-    "diameter_mm" : 9.11,
-    "diameter_inch" : 0.35866161099999994
+    "diameter_mm" : "9.11"
   },
   "360 Nitro Express 21/4" : {
     "name" : "360 Nitro Express 21/4",
     "names" : [ "360 N.E. 21/4" ],
     "specs" : {
-      "coal_mm" : 76.2,
-      "coal_inch" : 3.00000162
+      "coal_mm" : "76.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page91.pdf" ],
-    "diameter_mm" : 9.32,
-    "diameter_inch" : 0.366929332
+    "diameter_mm" : "9.32"
   },
   "369 Nitro Express Purdey" : {
     "name" : "369 Nitro Express Purdey",
     "names" : [ "369 N.E. Purdey" ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page92.pdf" ],
-    "diameter_mm" : 9.52,
-    "diameter_inch" : 0.374803352
+    "diameter_mm" : "9.52"
   },
   "375 Blaser Magnum" : {
     "name" : "375 Blaser Magnum",
     "names" : [ "375 Blaser Mag." ],
     "specs" : {
-      "coal_mm" : 92.0,
-      "coal_inch" : 3.6220491999999997
+      "coal_mm" : "92.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page140.pdf" ],
-    "diameter_mm" : 9.53,
-    "diameter_inch" : 0.37519705299999995
+    "diameter_mm" : "9.53"
   },
   "375 Chey Tac" : {
     "name" : "375 Chey Tac",
     "names" : [ "9,5 x 77" ],
     "specs" : {
-      "coal_mm" : 113.4,
-      "coal_inch" : 4.46456934
+      "coal_mm" : "113.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/375-chey-tac-170627-en.pdf" ],
-    "diameter_mm" : 9.52,
-    "diameter_inch" : 0.374803352
+    "diameter_mm" : "9.52"
   },
   "375 Flanged Magnum Nitro Express" : {
     "name" : "375 Flanged Magnum Nitro Express",
     "names" : [ "375 H&H Fl. Mag. N.E.", "375 Fl. Mag. N.E." ],
     "specs" : {
-      "coal_mm" : 96.52,
-      "coal_inch" : 3.8000020519999995
+      "coal_mm" : "96.52"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/375-fi-mag-ne-en.pdf" ],
-    "diameter_mm" : 9.52,
-    "diameter_inch" : 0.374803352
+    "diameter_mm" : "9.52"
   },
   "375 Flanged Nitro Express 21/2" : {
     "name" : "375 Flanged Nitro Express 21/2",
     "names" : [ "375 Fl. N.E. 21/2" ],
     "specs" : {
-      "coal_mm" : 82.55,
-      "coal_inch" : 3.2500017549999995
+      "coal_mm" : "82.55"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page93.pdf" ],
-    "diameter_mm" : 9.52,
-    "diameter_inch" : 0.374803352
+    "diameter_mm" : "9.52"
   },
   "375 Holland & Holland Magnum" : {
     "name" : "375 Holland & Holland Magnum",
     "names" : [ "375 H&H Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page27.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   },
   "375 Hölderlin" : {
     "name" : "375 Hölderlin",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.0,
-      "coal_inch" : 3.4251986999999997
+      "coal_mm" : "87.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page141.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   },
   "375 R Hölderlin" : {
     "name" : "375 R Hölderlin",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.0,
-      "coal_inch" : 3.4251986999999997
+      "coal_mm" : "87.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page95.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   },
   "375 R Verney-Carron" : {
     "name" : "375 R Verney-Carron",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 92.25,
-      "coal_inch" : 3.631891725
+      "coal_mm" : "92.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page96.pdf" ],
-    "diameter_mm" : 9.53,
-    "diameter_inch" : 0.37519705299999995
+    "diameter_mm" : "9.53"
   },
   "375 Remington Ultra Magnum" : {
     "name" : "375 Remington Ultra Magnum",
     "names" : [ "375 Rem. Ultra Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page142.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   },
   "375 Ruger" : {
     "name" : "375 Ruger",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page143.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   },
   "375 Weatherby Magnum" : {
     "name" : "375 Weatherby Magnum",
     "names" : [ "375 Weath.Mag." ],
     "specs" : {
-      "coal_mm" : 90.5,
-      "coal_inch" : 3.56299405
+      "coal_mm" : "90.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page28.pdf" ],
-    "diameter_mm" : 9.53,
-    "diameter_inch" : 0.37519705299999995
+    "diameter_mm" : "9.53"
   },
   "375 Winchester" : {
     "name" : "375 Winchester",
     "names" : [ "375 Win." ],
     "specs" : {
-      "coal_mm" : 65.02,
-      "coal_inch" : 2.559843902
+      "coal_mm" : "65.02"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page97.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   },
   "376 Steyr" : {
     "name" : "376 Steyr",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 79.0,
-      "coal_inch" : 3.1102379
+      "coal_mm" : "79.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page144.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   },
   "378 Weatherby Magnum" : {
     "name" : "378 Weatherby Magnum",
     "names" : [ "378 Weath.Mag." ],
     "specs" : {
-      "coal_mm" : 92.84,
-      "coal_inch" : 3.655120084
+      "coal_mm" : "92.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page29.pdf" ],
-    "diameter_mm" : 9.53,
-    "diameter_inch" : 0.37519705299999995
+    "diameter_mm" : "9.53"
   },
   "38-40 Winchester" : {
     "name" : "38-40 Winchester",
     "names" : [ "38-40 Win." ],
     "specs" : {
-      "coal_mm" : 40.44,
-      "coal_inch" : 1.5921268439999998
+      "coal_mm" : "40.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page98.pdf" ],
-    "diameter_mm" : 10.17,
-    "diameter_inch" : 0.400393917
+    "diameter_mm" : "10.17"
   },
   "38-55 Winchester" : {
     "name" : "38-55 Winchester",
     "names" : [ "38-55 Win." ],
     "specs" : {
-      "coal_mm" : 63.75,
-      "coal_inch" : 2.509843875
+      "coal_mm" : "63.75"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page99.pdf" ],
-    "diameter_mm" : 9.58,
-    "diameter_inch" : 0.377165558
+    "diameter_mm" : "9.58"
   },
   "380 Long Rifle" : {
     "name" : "380 Long Rifle",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 34.04,
-      "coal_inch" : 1.340158204
+      "coal_mm" : "34.04"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page100.pdf" ],
-    "diameter_mm" : 9.47,
-    "diameter_inch" : 0.372834847
+    "diameter_mm" : "9.47"
   },
   "4 Bore Rifle" : {
     "name" : "4 Bore Rifle",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 119.3,
-      "coal_inch" : 4.6968529299999995
+      "coal_mm" : "119.3"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page132.pdf" ],
-    "diameter_mm" : 25.4,
-    "diameter_inch" : 1.0000005399999998
+    "diameter_mm" : "25.4"
   },
   "4.6 x 30" : {
     "name" : "4.6 x 30",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 38.5,
-      "coal_inch" : 1.51574885
+      "coal_mm" : "38.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/4-6-x-30-en.pdf" ],
-    "diameter_mm" : 4.65,
-    "diameter_inch" : 0.183070965
+    "diameter_mm" : "4.65"
   },
   "40-60 Winchester" : {
     "name" : "40-60 Winchester",
     "names" : [ "40-60 Win" ],
     "specs" : {
-      "coal_mm" : 57.28,
-      "coal_inch" : 2.255119328
+      "coal_mm" : "57.28"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page101.pdf" ],
-    "diameter_mm" : 10.31,
-    "diameter_inch" : 0.405905731
+    "diameter_mm" : "10.31"
   },
   "40-65 Winchester" : {
     "name" : "40-65 Winchester",
     "names" : [ "40-65 Win." ],
     "specs" : {
-      "coal_mm" : 62.74,
-      "coal_inch" : 2.470080074
+      "coal_mm" : "62.74"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/40-65-win-170428-en.pdf" ],
-    "diameter_mm" : 10.31,
-    "diameter_inch" : 0.405905731
+    "diameter_mm" : "10.31"
   },
   "40-82 Winchester" : {
     "name" : "40-82 Winchester",
     "names" : [ "40-82 Win." ],
     "specs" : {
-      "coal_mm" : 70.23,
-      "coal_inch" : 2.764962123
+      "coal_mm" : "70.23"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page102.pdf" ],
-    "diameter_mm" : 10.35,
-    "diameter_inch" : 0.407480535
+    "diameter_mm" : "10.35"
   },
   "400 Holland & Holland Belted Magnum" : {
     "name" : "400 Holland & Holland Belted Magnum",
     "names" : [ "400 H&H Belt. Mag." ],
     "specs" : {
-      "coal_mm" : 90.0,
-      "coal_inch" : 3.543309
+      "coal_mm" : "90.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page30.pdf" ],
-    "diameter_mm" : 10.44,
-    "diameter_inch" : 0.41102384399999997
+    "diameter_mm" : "10.44"
   },
   "400 Purdey 3”" : {
     "name" : "400 Purdey 3”",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page103.pdf" ],
-    "diameter_mm" : 10.29,
-    "diameter_inch" : 0.40511832899999994
+    "diameter_mm" : "10.29"
   },
   "400/350 Nitro Express" : {
     "name" : "400/350 Nitro Express",
     "names" : [ "400/350 N.E." ],
     "specs" : {
-      "coal_mm" : 93.73,
-      "coal_inch" : 3.690159473
+      "coal_mm" : "93.73"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page104.pdf" ],
-    "diameter_mm" : 9.04,
-    "diameter_inch" : 0.35590570399999993
+    "diameter_mm" : "9.04"
   },
   "401 Winchester Self-loading" : {
     "name" : "401 Winchester Self-loading",
     "names" : [ "401 Win. SL" ],
     "specs" : {
-      "coal_mm" : 50.93,
-      "coal_inch" : 2.005119193
+      "coal_mm" : "50.93"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page105.pdf" ],
-    "diameter_mm" : 10.34,
-    "diameter_inch" : 0.40708683399999995
+    "diameter_mm" : "10.34"
   },
   "404 Rimless Nitro Express" : {
     "name" : "404 Rimless Nitro Express",
     "names" : [ "404 Riml. N.E." ],
     "specs" : {
-      "coal_mm" : 89.66,
-      "coal_inch" : 3.5299231659999997
+      "coal_mm" : "89.66"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page145.pdf" ],
-    "diameter_mm" : 10.72,
-    "diameter_inch" : 0.422047472
+    "diameter_mm" : "10.72"
   },
   "405 Winchester" : {
     "name" : "405 Winchester",
     "names" : [ "405 Win." ],
     "specs" : {
-      "coal_mm" : 80.64,
-      "coal_inch" : 3.174804864
+      "coal_mm" : "80.64"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page106.pdf" ],
-    "diameter_mm" : 10.45,
-    "diameter_inch" : 0.41141754499999994
+    "diameter_mm" : "10.45"
   },
   "408 Chey Tac" : {
     "name" : "408 Chey Tac",
     "names" : [ "10,36 x 77 mm" ],
     "specs" : {
-      "coal_mm" : 115.5,
-      "coal_inch" : 4.54724655
+      "coal_mm" : "115.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/408-chey-tac-en.pdf" ],
-    "diameter_mm" : 10.36,
-    "diameter_inch" : 0.40787423599999995
+    "diameter_mm" : "10.36"
   },
   "408 Winchester" : {
     "name" : "408 Winchester",
     "names" : [ "408 Win." ],
     "specs" : {
-      "coal_mm" : 65.53,
-      "coal_inch" : 2.579922653
+      "coal_mm" : "65.53"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page107.pdf" ],
-    "diameter_mm" : 10.31,
-    "diameter_inch" : 0.405905731
+    "diameter_mm" : "10.31"
   },
   "416 A-TEC" : {
     "name" : "416 A-TEC",
     "names" : [ "416 A-SUB" ],
     "specs" : {
-      "coal_mm" : 71.0,
-      "coal_inch" : 2.7952771
+      "coal_mm" : "71.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/416-a-tec-en.pdf" ],
-    "diameter_mm" : 10.57,
-    "diameter_inch" : 0.416141957
+    "diameter_mm" : "10.57"
   },
   "416 Barrett" : {
     "name" : "416 Barrett",
     "names" : [ "10,4 x 83" ],
     "specs" : {
-      "coal_mm" : 118.11,
-      "coal_inch" : 4.650002510999999
+      "coal_mm" : "118.11"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/416-barrett-en.pdf" ],
-    "diameter_mm" : 10.57,
-    "diameter_inch" : 0.416141957
+    "diameter_mm" : "10.57"
   },
   "416 Remington Magnum" : {
     "name" : "416 Remington Magnum",
     "names" : [ "416 Rem. Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page31.pdf" ],
-    "diameter_mm" : 10.57,
-    "diameter_inch" : 0.416141957
+    "diameter_mm" : "10.57"
   },
   "416 Rigby" : {
     "name" : "416 Rigby",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 95.25,
-      "coal_inch" : 3.7500020249999997
+      "coal_mm" : "95.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page146.pdf" ],
-    "diameter_mm" : 10.57,
-    "diameter_inch" : 0.416141957
+    "diameter_mm" : "10.57"
   },
   "416 Ruger" : {
     "name" : "416 Ruger",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page147.pdf" ],
-    "diameter_mm" : 10.58,
-    "diameter_inch" : 0.416535658
+    "diameter_mm" : "10.58"
   },
   "416 Taylor" : { },
   "416 Taylor Magnum" : {
     "name" : "416 Taylor Magnum",
     "names" : [ "416 Taylor Mag." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/416-taylor-mag-en.pdf" ],
-    "diameter_mm" : 10.57,
-    "diameter_inch" : 0.416141957
+    "diameter_mm" : "10.57"
   },
   "416 Weatherby Magnum" : {
     "name" : "416 Weatherby Magnum",
     "names" : [ "416 Weath.Mag." ],
     "specs" : {
-      "coal_mm" : 95.25,
-      "coal_inch" : 3.7500020249999997
+      "coal_mm" : "95.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page33.pdf" ],
-    "diameter_mm" : 10.57,
-    "diameter_inch" : 0.416141957
+    "diameter_mm" : "10.57"
   },
   "44-40 Winchester" : {
     "name" : "44-40 Winchester",
     "names" : [ "44-40 Win." ],
     "specs" : {
-      "coal_mm" : 40.44,
-      "coal_inch" : 1.5921268439999998
+      "coal_mm" : "40.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page108.pdf" ],
-    "diameter_mm" : 10.85,
-    "diameter_inch" : 0.42716558499999996
+    "diameter_mm" : "10.85"
   },
   "444 Marlin" : {
     "name" : "444 Marlin",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 65.28,
-      "coal_inch" : 2.570080128
+      "coal_mm" : "65.28"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page109.pdf" ],
-    "diameter_mm" : 10.93,
-    "diameter_inch" : 0.430315193
+    "diameter_mm" : "10.93"
   },
   "45 Blaser" : {
     "name" : "45 Blaser",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 68.5,
-      "coal_inch" : 2.69685185
+      "coal_mm" : "68.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page148.pdf" ],
-    "diameter_mm" : 11.64,
-    "diameter_inch" : 0.458267964
+    "diameter_mm" : "11.64"
   },
   "45-110 Sharps 2\" 7/8" : {
     "name" : "45-110 Sharps 2\" 7/8",
     "names" : [ "45-110 Sharps 2\"7/8" ],
     "specs" : {
-      "coal_mm" : 85.3,
-      "coal_inch" : 3.35826953
+      "coal_mm" : "85.3"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/45-110-sharps-170428-en.pdf" ],
-    "diameter_mm" : 11.63,
-    "diameter_inch" : 0.457874263
+    "diameter_mm" : "11.63"
   },
   "45-120 Sharps 3\" 1/4" : {
     "name" : "45-120 Sharps 3\" 1/4",
     "names" : [ "45-120 Sharps 3\"1/4" ],
     "specs" : {
-      "coal_mm" : 105.66,
-      "coal_inch" : 4.159844766
+      "coal_mm" : "105.66"
     },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/45-120-sharps-170428-en.pdf" ],
-    "diameter_mm" : 11.63,
-    "diameter_inch" : 0.457874263
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/45-120-sharps-3-1-4-180803-en.pdf" ],
+    "diameter_mm" : "11.63"
   },
   "45-60 Winchester" : {
     "name" : "45-60 Winchester",
     "names" : [ "45-60 Win" ],
     "specs" : {
-      "coal_mm" : 57.28,
-      "coal_inch" : 2.255119328
+      "coal_mm" : "57.28"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page110.pdf" ],
-    "diameter_mm" : 11.66,
-    "diameter_inch" : 0.45905536599999996
+    "diameter_mm" : "11.66"
   },
   "45-70 Elko Magnum" : {
     "name" : "45-70 Elko Magnum",
     "names" : [ "45-70 Elko Mag." ],
     "specs" : {
-      "coal_mm" : 87.3,
-      "coal_inch" : 3.4370097299999998
+      "coal_mm" : "87.3"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page111.pdf" ],
-    "diameter_mm" : 11.66,
-    "diameter_inch" : 0.45905536599999996
+    "diameter_mm" : "11.66"
   },
   "45-70 Government" : {
     "name" : "45-70 Government",
     "names" : [ "45-70 Govt." ],
     "specs" : {
-      "coal_mm" : 64.77,
-      "coal_inch" : 2.5500013769999996
+      "coal_mm" : "64.77"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page112.pdf" ],
-    "diameter_mm" : 11.63,
-    "diameter_inch" : 0.457874263
+    "diameter_mm" : "11.63"
   },
   "45-75 Winchester" : {
     "name" : "45-75 Winchester",
     "names" : [ "45-75 Win" ],
     "specs" : {
-      "coal_mm" : 57.28,
-      "coal_inch" : 2.255119328
+      "coal_mm" : "57.28"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page113.pdf" ],
-    "diameter_mm" : 11.66,
-    "diameter_inch" : 0.45905536599999996
+    "diameter_mm" : "11.66"
   },
   "45-90 WM" : {
     "name" : "45-90 WM",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page114.pdf" ],
-    "diameter_mm" : 11.63,
-    "diameter_inch" : 0.457874263
+    "diameter_mm" : "11.63"
   },
   "450 Bushmaster" : {
     "name" : "450 Bushmaster",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 57.4,
-      "coal_inch" : 2.25984374
+      "coal_mm" : "57.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page149.pdf" ],
-    "diameter_mm" : 11.49,
-    "diameter_inch" : 0.452362449
+    "diameter_mm" : "11.49"
   },
   "450 Marlin" : {
     "name" : "450 Marlin",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 64.76,
-      "coal_inch" : 2.549607676
+      "coal_mm" : "64.76"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page34.pdf" ],
-    "diameter_mm" : 11.64,
-    "diameter_inch" : 0.458267964
+    "diameter_mm" : "11.64"
   },
   "450 Nitro Express 3\" 1/4" : {
     "name" : "450 Nitro Express 3\" 1/4",
     "names" : [ "450 N.E. 3\" 1/4" ],
     "specs" : {
-      "coal_mm" : 100.33,
-      "coal_inch" : 3.950002133
+      "coal_mm" : "100.33"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/450-ne-3-1-4-en.pdf" ],
-    "diameter_mm" : 11.63,
-    "diameter_inch" : 0.457874263
+    "diameter_mm" : "11.63"
   },
   "450 N° 2 Nitro Express 3\" 1/2 Eley" : {
     "name" : "450 N° 2 Nitro Express 3\" 1/2 Eley",
     "names" : [ "450 N° 2 N.E. 3“1/2Eley" ],
     "specs" : {
-      "coal_mm" : 109.98,
-      "coal_inch" : 4.329923598
+      "coal_mm" : "109.98"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page116.pdf" ],
-    "diameter_mm" : 11.63,
-    "diameter_inch" : 0.457874263
+    "diameter_mm" : "11.63"
   },
   "450 Rigby" : {
     "name" : "450 Rigby",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 95.25,
-      "coal_inch" : 3.7500020249999997
+      "coal_mm" : "95.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/450-rigby-en.pdf" ],
-    "diameter_mm" : 11.66,
-    "diameter_inch" : 0.45905536599999996
+    "diameter_mm" : "11.66"
   },
   "450/400 Magnum Nitro Express 31/4" : {
     "name" : "450/400 Magnum Nitro Express 31/4",
     "names" : [ "450/400 Mag. N.E. 31/4" ],
     "specs" : {
-      "coal_mm" : 100.33,
-      "coal_inch" : 3.950002133
+      "coal_mm" : "100.33"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page118.pdf" ],
-    "diameter_mm" : 10.41,
-    "diameter_inch" : 0.409842741
+    "diameter_mm" : "10.41"
   },
   "450/400 Nitro Express 3" : {
     "name" : "450/400 Nitro Express 3",
     "names" : [ "450/400 N.E. 3" ],
     "specs" : {
-      "coal_mm" : 95.25,
-      "coal_inch" : 3.7500020249999997
+      "coal_mm" : "95.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page117.pdf" ],
-    "diameter_mm" : 10.41,
-    "diameter_inch" : 0.409842741
+    "diameter_mm" : "10.41"
   },
   "458 Lott" : {
     "name" : "458 Lott",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/458-lott-en.pdf" ],
-    "diameter_mm" : 11.66,
-    "diameter_inch" : 0.45905536599999996
+    "diameter_mm" : "11.66"
   },
   "458 Winchester Magnum" : {
     "name" : "458 Winchester Magnum",
     "names" : [ "458 Win. Mag." ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page36.pdf" ],
-    "diameter_mm" : 11.66,
-    "diameter_inch" : 0.45905536599999996
+    "diameter_mm" : "11.66"
   },
   "460 Steyr" : {
     "name" : "460 Steyr",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 140.0,
-      "coal_inch" : 5.511813999999999
+      "coal_mm" : "140.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page151.pdf" ],
-    "diameter_mm" : 11.65,
-    "diameter_inch" : 0.458661665
+    "diameter_mm" : "11.65"
   },
   "460 Weatherby Magnum" : {
     "name" : "460 Weatherby Magnum",
     "names" : [ "460 Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 95.25,
-      "coal_inch" : 3.7500020249999997
+      "coal_mm" : "95.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page37.pdf" ],
-    "diameter_mm" : 11.64,
-    "diameter_inch" : 0.458267964
+    "diameter_mm" : "11.64"
   },
   "465 Holland & Holland Belted Magnum" : {
     "name" : "465 Holland & Holland Belted Magnum",
     "names" : [ "465 H&H Belt. Mag." ],
     "specs" : {
-      "coal_mm" : 90.0,
-      "coal_inch" : 3.543309
+      "coal_mm" : "90.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page38.pdf" ],
-    "diameter_mm" : 11.89,
-    "diameter_inch" : 0.468110489
+    "diameter_mm" : "11.89"
   },
   "470 Nitro Express" : {
     "name" : "470 Nitro Express",
     "names" : [ "470 N.E." ],
     "specs" : {
-      "coal_mm" : 101.09,
-      "coal_inch" : 3.979923409
+      "coal_mm" : "101.09"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/470-ne-en.pdf" ],
-    "diameter_mm" : 12.04,
-    "diameter_inch" : 0.47401600399999994
+    "diameter_mm" : "12.04"
   },
   "475 N° 2 Nitro Express 3\" 1/2 Jeffery" : {
     "name" : "475 N° 2 Nitro Express 3\" 1/2 Jeffery",
     "names" : [ "475 N° 2 N.E. 3“1/2 Jeffery" ],
     "specs" : {
-      "coal_mm" : 109.98,
-      "coal_inch" : 4.329923598
+      "coal_mm" : "109.98"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page121.pdf" ],
-    "diameter_mm" : 12.39,
-    "diameter_inch" : 0.487795539
+    "diameter_mm" : "12.39"
   },
   "475 N° 2 Nitro Express 31/2" : {
     "name" : "475 N° 2 Nitro Express 31/2",
     "names" : [ "475 N° 2 N.E. 31/2" ],
     "specs" : {
-      "coal_mm" : 109.98,
-      "coal_inch" : 4.329923598
+      "coal_mm" : "109.98"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page120.pdf" ],
-    "diameter_mm" : 12.27,
-    "diameter_inch" : 0.48307112699999993
+    "diameter_mm" : "12.27"
   },
   "5.45 x 39" : {
     "name" : "5.45 x 39",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 57.0,
-      "coal_inch" : 2.2440957
+      "coal_mm" : "57.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/5-45-x-39-en.pdf" ],
-    "diameter_mm" : 5.6,
-    "diameter_inch" : 0.22047255999999998
+    "diameter_mm" : "5.6"
   },
   "5.6 x 35 R" : {
     "name" : "5.6 x 35 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 43.5,
-      "coal_inch" : 1.7125993499999999
+      "coal_mm" : "43.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page1.pdf" ],
-    "diameter_mm" : 5.63,
-    "diameter_inch" : 0.22165366299999997
+    "diameter_mm" : "5.63"
   },
   "5.6 x 39" : {
     "name" : "5.6 x 39",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 48.7,
-      "coal_inch" : 1.91732387
+      "coal_mm" : "48.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page3.pdf" ],
-    "diameter_mm" : 5.67,
-    "diameter_inch" : 0.22322846699999999
+    "diameter_mm" : "5.67"
   },
   "5.6 x 50 Magnum" : {
     "name" : "5.6 x 50 Magnum",
     "names" : [ "5.6 x 50 Mag." ],
     "specs" : {
-      "coal_mm" : 61.3,
-      "coal_inch" : 2.41338713
+      "coal_mm" : "61.3"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page4.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "5.6 x 50 R Magnum" : {
     "name" : "5.6 x 50 R Magnum",
     "names" : [ "5.6 x 50 R Mag." ],
     "specs" : {
-      "coal_mm" : 61.0,
-      "coal_inch" : 2.4015760999999998
+      "coal_mm" : "61.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page2.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "5.6 x 52 R" : {
     "name" : "5.6 x 52 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 63.75,
-      "coal_inch" : 2.509843875
+      "coal_mm" : "63.75"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page3.pdf" ],
-    "diameter_mm" : 5.79,
-    "diameter_inch" : 0.227952879
+    "diameter_mm" : "5.79"
   },
   "5.6 x 57" : {
     "name" : "5.6 x 57",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 69.0,
-      "coal_inch" : 2.7165369
+      "coal_mm" : "69.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page5.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "5.6 x 57 R" : {
     "name" : "5.6 x 57 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 69.0,
-      "coal_inch" : 2.7165369
+      "coal_mm" : "69.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page4.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "5.6 x 61 R Super Express Vom Hofe" : {
     "name" : "5.6 x 61 R Super Express Vom Hofe",
     "names" : [ "5.6 x 61 R SE v. H." ],
     "specs" : {
-      "coal_mm" : 80.0,
-      "coal_inch" : 3.1496079999999997
+      "coal_mm" : "80.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page5.pdf" ],
-    "diameter_mm" : 5.76,
-    "diameter_inch" : 0.22677177599999998
+    "diameter_mm" : "5.76"
   },
   "5.6 x 61 Super Express Vom Hofe" : {
     "name" : "5.6 x 61 Super Express Vom Hofe",
     "names" : [ "5.6 x 61 SE v. H." ],
     "specs" : {
-      "coal_mm" : 80.0,
-      "coal_inch" : 3.1496079999999997
+      "coal_mm" : "80.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page6.pdf" ],
-    "diameter_mm" : 5.79,
-    "diameter_inch" : 0.227952879
+    "diameter_mm" : "5.79"
   },
   "5.6 x 70 R" : {
     "name" : "5.6 x 70 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.0,
-      "coal_inch" : 3.4251986999999997
+      "coal_mm" : "87.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page6.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "5.7 x 28" : {
     "name" : "5.7 x 28",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 40.5,
-      "coal_inch" : 1.59448905
+      "coal_mm" : "40.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page7.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "50 Browning" : {
     "name" : "50 Browning",
     "names" : [ "12,7 x 99" ],
     "specs" : {
-      "coal_mm" : 138.43,
-      "coal_inch" : 5.450002943
+      "coal_mm" : "138.43"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/50-browning-en.pdf" ],
-    "diameter_mm" : 12.98,
-    "diameter_inch" : 0.511023898
+    "diameter_mm" : "12.98"
   },
   "50-70 Government" : {
     "name" : "50-70 Government",
     "names" : [ "50-70 Musket", "50-70 Govt." ],
     "specs" : {
-      "coal_mm" : 57.15,
-      "coal_inch" : 2.2500012149999997
+      "coal_mm" : "57.15"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/50-70-govt-170428-en.pdf" ],
-    "diameter_mm" : 13.08,
-    "diameter_inch" : 0.5149609079999999
+    "diameter_mm" : "13.08"
   },
   "50-90 Sharps 2\" 1/2" : {
     "name" : "50-90 Sharps 2\" 1/2",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 81.28,
-      "coal_inch" : 3.2000017279999997
+      "coal_mm" : "81.28"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/50-90-sharps-170309-en.pdf" ],
-    "diameter_mm" : 13.08,
-    "diameter_inch" : 0.5149609079999999
+    "diameter_mm" : "13.08"
   },
   "50-95 Winchester" : {
     "name" : "50-95 Winchester",
     "names" : [ "50-95 Win." ],
     "specs" : {
-      "coal_mm" : 57.4,
-      "coal_inch" : 2.25984374
+      "coal_mm" : "57.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page122.pdf" ],
-    "diameter_mm" : 13.03,
-    "diameter_inch" : 0.5129924029999999
+    "diameter_mm" : "13.03"
   },
   "500 Jeffery" : {
     "name" : "500 Jeffery",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 88.09,
-      "coal_inch" : 3.4681121089999998
+      "coal_mm" : "88.09"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page153.pdf" ],
-    "diameter_mm" : 12.95,
-    "diameter_inch" : 0.509842795
+    "diameter_mm" : "12.95"
   },
   "500 Nitro Express 3\"" : {
     "name" : "500 Nitro Express 3\"",
     "names" : [ "500 N.E. 3\"" ],
     "specs" : {
-      "coal_mm" : 95.25,
-      "coal_inch" : 3.7500020249999997
+      "coal_mm" : "95.25"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/500-n-e-3-en.pdf" ],
-    "diameter_mm" : 12.95,
-    "diameter_inch" : 0.509842795
+    "diameter_mm" : "12.95"
   },
   "500/416 Nitro Express 3\" 1/4" : {
     "name" : "500/416 Nitro Express 3\" 1/4",
     "names" : [ "500/416 N.E. 3“1/4" ],
     "specs" : {
-      "coal_mm" : 101.09,
-      "coal_inch" : 3.979923409
+      "coal_mm" : "101.09"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page124.pdf" ],
-    "diameter_mm" : 10.57,
-    "diameter_inch" : 0.416141957
+    "diameter_mm" : "10.57"
   },
   "500/465 Nitro Express" : {
     "name" : "500/465 Nitro Express",
     "names" : [ "500/465 N.E." ],
     "specs" : {
-      "coal_mm" : 99.06,
-      "coal_inch" : 3.900002106
+      "coal_mm" : "99.06"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page125.pdf" ],
-    "diameter_mm" : 11.89,
-    "diameter_inch" : 0.468110489
+    "diameter_mm" : "11.89"
   },
   "505 Magnum Gibbs" : {
     "name" : "505 Magnum Gibbs",
     "names" : [ "505 Mag. Gibbs" ],
     "specs" : {
-      "coal_mm" : 97.79,
-      "coal_inch" : 3.8500020790000002
+      "coal_mm" : "97.79"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page154.pdf" ],
-    "diameter_mm" : 12.83,
-    "diameter_inch" : 0.505118383
+    "diameter_mm" : "12.83"
   },
   "510 DTC" : {
     "name" : "510 DTC",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 137.47,
-      "coal_inch" : 5.412207647
+      "coal_mm" : "137.47"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page155.pdf" ],
-    "diameter_mm" : 12.98,
-    "diameter_inch" : 0.511023898
+    "diameter_mm" : "12.98"
   },
   "56/50 Spencer" : {
     "name" : "56/50 Spencer",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 38.56,
-      "coal_inch" : 1.518111056
+      "coal_mm" : "38.56"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page126.pdf" ],
-    "diameter_mm" : 13.0,
-    "diameter_inch" : 0.5118113
+    "diameter_mm" : "13.0"
   },
   "577 Nitro Express 3\"" : {
     "name" : "577 Nitro Express 3\"",
     "names" : [ "577 N.E. 3\"" ],
     "specs" : {
-      "coal_mm" : 93.98,
-      "coal_inch" : 3.700001998
+      "coal_mm" : "93.98"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/577-ne-3-en.pdf" ],
-    "diameter_mm" : 14.83,
-    "diameter_inch" : 0.5838585829999999
+    "diameter_mm" : "14.83"
   },
   "577 Sld. Snider" : {
     "name" : "577 Sld. Snider",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 62.74,
-      "coal_inch" : 2.470080074
+      "coal_mm" : "62.74"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page129.pdf" ],
-    "diameter_mm" : 14.58,
-    "diameter_inch" : 0.574016058
+    "diameter_mm" : "14.58"
   },
   "577/450 Sld. Martini–Henry" : {
     "name" : "577/450 Sld. Martini–Henry",
     "names" : [ "577/450 Sld. Mart.H." ],
     "specs" : {
-      "coal_mm" : 81.28,
-      "coal_inch" : 3.2000017279999997
+      "coal_mm" : "81.28"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page127.pdf" ],
-    "diameter_mm" : 11.81,
-    "diameter_inch" : 0.464960881
+    "diameter_mm" : "11.81"
   },
   "5mm / 35 SMc" : {
     "name" : "5mm / 35 SMc",
@@ -2759,157 +2301,131 @@
     "name" : "6 XC",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 70.0,
-      "coal_inch" : 2.7559069999999997
+      "coal_mm" : "70.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page17.pdf" ],
-    "diameter_mm" : 6.18,
-    "diameter_inch" : 0.24330721799999996
+    "diameter_mm" : "6.18"
   },
   "6 x 47 ATZL" : {
     "name" : "6 x 47 ATZL",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 63.0,
-      "coal_inch" : 2.4803162999999997
+      "coal_mm" : "63.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-x-47-atzl-en.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6 x 47 SM" : {
     "name" : "6 x 47 SM",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 66.0,
-      "coal_inch" : 2.5984266
+      "coal_mm" : "66.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page9.pdf" ],
-    "diameter_mm" : 6.18,
-    "diameter_inch" : 0.24330721799999996
+    "diameter_mm" : "6.18"
   },
   "6 x 50 R Scheiring" : {
     "name" : "6 x 50 R Scheiring",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 69.0,
-      "coal_inch" : 2.7165369
+      "coal_mm" : "69.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page7.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6 x 51 ATZL" : {
     "name" : "6 x 51 ATZL",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 68.0,
-      "coal_inch" : 2.6771667999999997
+      "coal_mm" : "68.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page10.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6 x 52 R BB2" : {
     "name" : "6 x 52 R BB2",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 69.0,
-      "coal_inch" : 2.7165369
+      "coal_mm" : "69.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page8.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6 x 52 R Bretschneider" : {
     "name" : "6 x 52 R Bretschneider",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 68.5,
-      "coal_inch" : 2.69685185
+      "coal_mm" : "68.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page9.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6 x 62 Freres" : {
     "name" : "6 x 62 Freres",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page11.pdf" ],
-    "diameter_mm" : 6.18,
-    "diameter_inch" : 0.24330721799999996
+    "diameter_mm" : "6.18"
   },
   "6 x 62 R Freres" : {
     "name" : "6 x 62 R Freres",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page10.pdf" ],
-    "diameter_mm" : 6.18,
-    "diameter_inch" : 0.24330721799999996
+    "diameter_mm" : "6.18"
   },
   "6 x 70 R" : {
     "name" : "6 x 70 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.0,
-      "coal_inch" : 3.4251986999999997
+      "coal_mm" : "87.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page11.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6.3 x 57 Farè" : {
     "name" : "6.3 x 57 Farè",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 75.0,
-      "coal_inch" : 2.9527574999999997
+      "coal_mm" : "75.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-3-x-57-fare-en.pdf" ],
-    "diameter_mm" : 6.52,
-    "diameter_inch" : 0.256693052
+    "diameter_mm" : "6.52"
   },
   "6.5 - 284 Norma" : {
     "name" : "6.5 - 284 Norma",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page18.pdf" ],
-    "diameter_mm" : 6.71,
-    "diameter_inch" : 0.264173371
+    "diameter_mm" : "6.71"
   },
   "6.5 Creedmoor" : {
     "name" : "6.5 Creedmoor",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 71.76,
-      "coal_inch" : 2.825198376
+      "coal_mm" : "71.76"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-creedmoor-en.pdf" ],
-    "diameter_mm" : 6.72,
-    "diameter_inch" : 0.26456707199999996
+    "diameter_mm" : "6.72"
   },
   "6.5 Grendel" : {
     "name" : "6.5 Grendel",
@@ -2922,121 +2438,101 @@
     "name" : "6.5 x 39",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 56.0,
-      "coal_inch" : 2.2047255999999997
+      "coal_mm" : "56.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-39-en.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 47 Lapua" : {
     "name" : "6.5 x 47 Lapua",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 71.0,
-      "coal_inch" : 2.7952771
+      "coal_mm" : "71.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-47-lapua-en.pdf" ],
-    "diameter_mm" : 6.71,
-    "diameter_inch" : 0.264173371
+    "diameter_mm" : "6.71"
   },
   "6.5 x 50 R" : {
     "name" : "6.5 x 50 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 68.0,
-      "coal_inch" : 2.6771667999999997
+      "coal_mm" : "68.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page12.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 51 R (Arisaka)" : {
     "name" : "6.5 x 51 R (Arisaka)",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 76.0,
-      "coal_inch" : 2.9921276
+      "coal_mm" : "76.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/6-5-x-51-r-arisaka-en.pdf" ],
-    "diameter_mm" : 6.63,
-    "diameter_inch" : 0.26102376299999996
+    "diameter_mm" : "6.63"
   },
   "6.5 x 52 Carcano" : {
     "name" : "6.5 x 52 Carcano",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 76.5,
-      "coal_inch" : 3.01181265
+      "coal_mm" : "76.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-52-carcano-en.pdf" ],
-    "diameter_mm" : 6.8,
-    "diameter_inch" : 0.26771668
+    "diameter_mm" : "6.8"
   },
   "6.5 x 52 R" : {
     "name" : "6.5 x 52 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 64.5,
-      "coal_inch" : 2.53937145
+      "coal_mm" : "64.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page14.pdf" ],
-    "diameter_mm" : 6.58,
-    "diameter_inch" : 0.259055258
+    "diameter_mm" : "6.58"
   },
   "6.5 x 52 R Keller & Simmann" : {
     "name" : "6.5 x 52 R Keller & Simmann",
     "names" : [ "6.5 x 52 R K&S" ],
     "specs" : {
-      "coal_mm" : 71.12,
-      "coal_inch" : 2.800001512
+      "coal_mm" : "71.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/6-5-x-52-r-k-s-en.pdf" ],
-    "diameter_mm" : 6.72,
-    "diameter_inch" : 0.26456707199999996
+    "diameter_mm" : "6.72"
   },
   "6.5 x 54 Mannlicher–Schönauer" : {
     "name" : "6.5 x 54 Mannlicher–Schönauer",
     "names" : [ "6.5 x 54 M.-Sch." ],
     "specs" : {
-      "coal_mm" : 77.8,
-      "coal_inch" : 3.0629937799999998
+      "coal_mm" : "77.8"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page22.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 54 Mauser" : {
     "name" : "6.5 x 54 Mauser",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 68.0,
-      "coal_inch" : 2.6771667999999997
+      "coal_mm" : "68.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page21.pdf" ],
-    "diameter_mm" : 6.64,
-    "diameter_inch" : 0.261417464
+    "diameter_mm" : "6.64"
   },
   "6.5 x 55 SE" : {
     "name" : "6.5 x 55 SE",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 80.0,
-      "coal_inch" : 3.1496079999999997
+      "coal_mm" : "80.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-55-se-en.pdf" ],
-    "diameter_mm" : 6.71,
-    "diameter_inch" : 0.264173371
+    "diameter_mm" : "6.71"
   },
   "6.5 x 55 T.R.I." : {
     "name" : "6.5 x 55 T.R.I.",
@@ -3049,145 +2545,121 @@
     "name" : "6.5 x 57",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page24.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 57 R" : {
     "name" : "6.5 x 57 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page15.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 58 Mauser" : {
     "name" : "6.5 x 58 Mauser",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.5,
-      "coal_inch" : 3.2480332499999998
+      "coal_mm" : "82.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page25.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 58 R" : {
     "name" : "6.5 x 58 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.0,
-      "coal_inch" : 3.0708678
+      "coal_mm" : "78.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page16.pdf" ],
-    "diameter_mm" : 6.64,
-    "diameter_inch" : 0.261417464
+    "diameter_mm" : "6.64"
   },
   "6.5 x 63 Messner Magnum" : {
     "name" : "6.5 x 63 Messner Magnum",
     "names" : [ "6.5 x 63 Messner Mag." ],
     "specs" : {
-      "coal_mm" : 84.5,
-      "coal_inch" : 3.3267734499999997
+      "coal_mm" : "84.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page26.pdf" ],
-    "diameter_mm" : 6.71,
-    "diameter_inch" : 0.264173371
+    "diameter_mm" : "6.71"
   },
   "6.5 x 64" : {
     "name" : "6.5 x 64",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.0,
-      "coal_inch" : 3.3070884
+      "coal_mm" : "84.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page27.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 64 Brenneke" : {
     "name" : "6.5 x 64 Brenneke",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.84,
-      "coal_inch" : 3.340159284
+      "coal_mm" : "84.84"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-x-64-brenneke-en.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 65 R Rheinisch-Westfälischen Sprengstoff-Fabriken" : {
     "name" : "6.5 x 65 R Rheinisch-Westfälischen Sprengstoff-Fabriken",
     "names" : [ "6.5 x 65 R RWS" ],
     "specs" : {
-      "coal_mm" : 85.0,
-      "coal_inch" : 3.3464585
+      "coal_mm" : "85.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page17.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 65 Rheinisch-Westfälischen Sprengstoff-Fabriken" : {
     "name" : "6.5 x 65 Rheinisch-Westfälischen Sprengstoff-Fabriken",
     "names" : [ "6.5 x 65 RWS" ],
     "specs" : {
-      "coal_mm" : 85.0,
-      "coal_inch" : 3.3464585
+      "coal_mm" : "85.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page29.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 68" : {
     "name" : "6.5 x 68",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 86.5,
-      "coal_inch" : 3.40551365
+      "coal_mm" : "86.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page30.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 68 R" : {
     "name" : "6.5 x 68 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.5,
-      "coal_inch" : 3.44488375
+      "coal_mm" : "87.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page18.pdf" ],
-    "diameter_mm" : 6.7,
-    "diameter_inch" : 0.26377967
+    "diameter_mm" : "6.7"
   },
   "6.5 x 70 R" : {
     "name" : "6.5 x 70 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 90.0,
-      "coal_inch" : 3.543309
+      "coal_mm" : "90.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page19.pdf" ],
-    "diameter_mm" : 6.64,
-    "diameter_inch" : 0.261417464
+    "diameter_mm" : "6.64"
   },
   "6.5mm D.B.G." : {
     "name" : "6.5mm D.B.G.",
@@ -3200,649 +2672,541 @@
     "name" : "6.5mm Lahoz",
     "names" : [ "6.5 mm Lahoz" ],
     "specs" : {
-      "coal_mm" : 57.4,
-      "coal_inch" : 2.25984374
+      "coal_mm" : "57.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-5-mm-lahoz-en.pdf" ],
-    "diameter_mm" : 6.71,
-    "diameter_inch" : 0.264173371
+    "diameter_mm" : "6.71"
   },
   "6.5mm Remington Magnum" : {
     "name" : "6.5mm Remington Magnum",
     "names" : [ "6.5 mm Rem. Mag." ],
     "specs" : {
-      "coal_mm" : 71.12,
-      "coal_inch" : 2.800001512
+      "coal_mm" : "71.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page1.pdf" ],
-    "diameter_mm" : 6.72,
-    "diameter_inch" : 0.26456707199999996
+    "diameter_mm" : "6.72"
   },
   "6.8mm Remington Special Purpose Cartridge" : {
     "name" : "6.8mm Remington Special Purpose Cartridge",
     "names" : [ "6.8 mm Rem. SPC" ],
     "specs" : {
-      "coal_mm" : 57.4,
-      "coal_inch" : 2.25984374
+      "coal_mm" : "57.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page31.pdf" ],
-    "diameter_mm" : 7.06,
-    "diameter_inch" : 0.27795290599999994
+    "diameter_mm" : "7.06"
   },
   "600 Nitro Express" : {
     "name" : "600 Nitro Express",
     "names" : [ "600 N.E." ],
     "specs" : {
-      "coal_mm" : 93.98,
-      "coal_inch" : 3.700001998
+      "coal_mm" : "93.98"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page130.pdf" ],
-    "diameter_mm" : 15.75,
-    "diameter_inch" : 0.6200790749999999
+    "diameter_mm" : "15.75"
   },
   "6mm Bench Rest Farè" : {
     "name" : "6mm Bench Rest Farè",
     "names" : [ "6 mm BR Farè" ],
     "specs" : {
-      "coal_mm" : 62.0,
-      "coal_inch" : 2.4409462
+      "coal_mm" : "62.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-mm-br-fare-en.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6mm Bench Rest Norma" : {
     "name" : "6mm Bench Rest Norma",
     "names" : [ "6 mm BR Norma" ],
     "specs" : {
-      "coal_mm" : 62.0,
-      "coal_inch" : 2.4409462
+      "coal_mm" : "62.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page12.pdf" ],
-    "diameter_mm" : 6.18,
-    "diameter_inch" : 0.24330721799999996
+    "diameter_mm" : "6.18"
   },
   "6mm Bench Rest Remington" : {
     "name" : "6mm Bench Rest Remington",
     "names" : [ "6 mm B.R. Rem." ],
     "specs" : {
-      "coal_mm" : 55.88,
-      "coal_inch" : 2.200001188
+      "coal_mm" : "55.88"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page13.pdf" ],
-    "diameter_mm" : 6.18,
-    "diameter_inch" : 0.24330721799999996
+    "diameter_mm" : "6.18"
   },
   "6mm D.B.G." : {
     "name" : "6mm D.B.G.",
     "names" : [ "6 mm D.B.G." ],
     "specs" : {
-      "coal_mm" : 58.0,
-      "coal_inch" : 2.2834658
+      "coal_mm" : "58.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-mm-dbg-en.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6mm Palmisano & Pindel Cartridge" : {
     "name" : "6mm Palmisano & Pindel Cartridge",
     "names" : [ "6 mm PPC" ],
     "specs" : {
-      "coal_mm" : 55.7,
-      "coal_inch" : 2.19291457
+      "coal_mm" : "55.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page14.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6mm Palmisano & Pindel Cartridge ITA" : {
     "name" : "6mm Palmisano & Pindel Cartridge ITA",
     "names" : [ "6 mm PPC ITA" ],
     "specs" : {
-      "coal_mm" : 55.7,
-      "coal_inch" : 2.19291457
+      "coal_mm" : "55.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/6-mm-ppc-ita-en.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6mm Palmisano & Pindel Cartridge-USA" : {
     "name" : "6mm Palmisano & Pindel Cartridge-USA",
     "names" : [ "6 mm PPC-USA" ],
     "specs" : {
-      "coal_mm" : 55.7,
-      "coal_inch" : 2.19291457
+      "coal_mm" : "55.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page15.pdf" ],
-    "diameter_mm" : 6.17,
-    "diameter_inch" : 0.242913517
+    "diameter_mm" : "6.17"
   },
   "6mm Remington (244 Remington)" : {
     "name" : "6mm Remington (244 Remington)",
     "names" : [ "6 mm Rem. (244 Rem.)" ],
     "specs" : {
-      "coal_mm" : 71.76,
-      "coal_inch" : 2.825198376
+      "coal_mm" : "71.76"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page16.pdf" ],
-    "diameter_mm" : 6.18,
-    "diameter_inch" : 0.24330721799999996
+    "diameter_mm" : "6.18"
   },
   "7 x 33 Sako" : {
     "name" : "7 x 33 Sako",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 44.44,
-      "coal_inch" : 1.749607244
+      "coal_mm" : "44.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page32.pdf" ],
-    "diameter_mm" : 7.26,
-    "diameter_inch" : 0.285826926
+    "diameter_mm" : "7.26"
   },
   "7 x 44 Penna" : {
     "name" : "7 x 44 Penna",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 60.0,
-      "coal_inch" : 2.362206
+      "coal_mm" : "60.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-x-44-penna-en.pdf" ],
-    "diameter_mm" : 7.04,
-    "diameter_inch" : 0.277165504
+    "diameter_mm" : "7.04"
   },
   "7 x 50 R" : {
     "name" : "7 x 50 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 68.0,
-      "coal_inch" : 2.6771667999999997
+      "coal_mm" : "68.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page21.pdf" ],
-    "diameter_mm" : 7.25,
-    "diameter_inch" : 0.285433225
+    "diameter_mm" : "7.25"
   },
   "7 x 57" : {
     "name" : "7 x 57",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.0,
-      "coal_inch" : 3.0708678
+      "coal_mm" : "78.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page33.pdf" ],
-    "diameter_mm" : 7.25,
-    "diameter_inch" : 0.285433225
+    "diameter_mm" : "7.25"
   },
   "7 x 57 R" : {
     "name" : "7 x 57 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.0,
-      "coal_inch" : 3.0708678
+      "coal_mm" : "78.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/7-x-57-r-en.pdf" ],
-    "diameter_mm" : 7.25,
-    "diameter_inch" : 0.285433225
+    "diameter_mm" : "7.25"
   },
   "7 x 61 Super" : {
     "name" : "7 x 61 Super",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 83.0,
-      "coal_inch" : 3.2677183
+      "coal_mm" : "83.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/7-x-61-super-en.pdf" ],
-    "diameter_mm" : 7.2,
-    "diameter_inch" : 0.28346472
+    "diameter_mm" : "7.2"
   },
   "7 x 64" : {
     "name" : "7 x 64",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.0,
-      "coal_inch" : 3.3070884
+      "coal_mm" : "84.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page34.pdf" ],
-    "diameter_mm" : 7.25,
-    "diameter_inch" : 0.285433225
+    "diameter_mm" : "7.25"
   },
   "7 x 65 R" : {
     "name" : "7 x 65 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 83.6,
-      "coal_inch" : 3.2913403599999995
+      "coal_mm" : "83.6"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page24.pdf" ],
-    "diameter_mm" : 7.25,
-    "diameter_inch" : 0.285433225
+    "diameter_mm" : "7.25"
   },
   "7 x 67 R Luyven" : {
     "name" : "7 x 67 R Luyven",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 90.0,
-      "coal_inch" : 3.543309
+      "coal_mm" : "90.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page25.pdf" ],
-    "diameter_mm" : 7.25,
-    "diameter_inch" : 0.285433225
+    "diameter_mm" : "7.25"
   },
   "7 x 72 R" : {
     "name" : "7 x 72 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 92.0,
-      "coal_inch" : 3.6220491999999997
+      "coal_mm" : "92.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page26.pdf" ],
-    "diameter_mm" : 7.25,
-    "diameter_inch" : 0.285433225
+    "diameter_mm" : "7.25"
   },
   "7 x 75 R Super Express Vom Hofe" : {
     "name" : "7 x 75 R Super Express Vom Hofe",
     "names" : [ "7 x 75 R SE.v. H." ],
     "specs" : {
-      "coal_mm" : 97.0,
-      "coal_inch" : 3.8188997
+      "coal_mm" : "97.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page27.pdf" ],
-    "diameter_mm" : 7.24,
-    "diameter_inch" : 0.285039524
+    "diameter_mm" : "7.24"
   },
   "7-30 Waters" : {
     "name" : "7-30 Waters",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 64.77,
-      "coal_inch" : 2.5500013769999996
+      "coal_mm" : "64.77"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page20.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7-47 Giani Special" : {
     "name" : "7-47 Giani Special",
     "names" : [ "7-47 GS" ],
     "specs" : {
-      "coal_mm" : 71.0,
-      "coal_inch" : 2.7952771
+      "coal_mm" : "71.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-47-gs-en.pdf" ],
-    "diameter_mm" : 7.06,
-    "diameter_inch" : 0.27795290599999994
+    "diameter_mm" : "7.06"
   },
   "7.21 Firebird" : {
     "name" : "7.21 Firebird",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 92.2,
-      "coal_inch" : 3.62992322
+      "coal_mm" : "92.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page44.pdf" ],
-    "diameter_mm" : 7.24,
-    "diameter_inch" : 0.285039524
+    "diameter_mm" : "7.24"
   },
   "7.5 x 54 Manufacture d'armes de Saint-Étienne" : {
     "name" : "7.5 x 54 Manufacture d'armes de Saint-Étienne",
     "names" : [ "7.5 x 54 MAS" ],
     "specs" : {
-      "coal_mm" : 76.0,
-      "coal_inch" : 2.9921276
+      "coal_mm" : "76.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-5-x-54-mas-en.pdf" ],
-    "diameter_mm" : 7.84,
-    "diameter_inch" : 0.308661584
+    "diameter_mm" : "7.84"
   },
   "7.5 x 55 Suisse" : {
     "name" : "7.5 x 55 Suisse",
     "names" : [ "7,5 x 55 Swiss" ],
     "specs" : {
-      "coal_mm" : 77.7,
-      "coal_inch" : 3.0590567699999998
+      "coal_mm" : "77.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-5-x-55-suisse-en.pdf" ],
-    "diameter_mm" : 7.78,
-    "diameter_inch" : 0.306299378
+    "diameter_mm" : "7.78"
   },
   "7.62 Uekötter Katzmeier Magnum" : {
     "name" : "7.62 Uekötter Katzmeier Magnum",
     "names" : [ "7.62 UKM" ],
     "specs" : {
-      "coal_mm" : 79.0,
-      "coal_inch" : 3.1102379
+      "coal_mm" : "79.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page49.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "7.62 x 39" : {
     "name" : "7.62 x 39",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 56.0,
-      "coal_inch" : 2.2047255999999997
+      "coal_mm" : "56.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-62-x-39-en.pdf" ],
-    "diameter_mm" : 7.92,
-    "diameter_inch" : 0.31181119199999996
+    "diameter_mm" : "7.92"
   },
   "7.62 x 45" : {
     "name" : "7.62 x 45",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 60.0,
-      "coal_inch" : 2.362206
+      "coal_mm" : "60.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page48.pdf" ],
-    "diameter_mm" : 7.83,
-    "diameter_inch" : 0.30826788299999996
+    "diameter_mm" : "7.83"
   },
   "7.62 x 53 R" : {
     "name" : "7.62 x 53 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 77.0,
-      "coal_inch" : 3.0314977
+      "coal_mm" : "77.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page28.pdf" ],
-    "diameter_mm" : 7.85,
-    "diameter_inch" : 0.30905528499999996
+    "diameter_mm" : "7.85"
   },
   "7.62 x 54 R" : {
     "name" : "7.62 x 54 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 77.16,
-      "coal_inch" : 3.0377969159999996
+      "coal_mm" : "77.16"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/7-62-x-54-r-en.pdf" ],
-    "diameter_mm" : 7.92,
-    "diameter_inch" : 0.31181119199999996
+    "diameter_mm" : "7.92"
   },
   "7.65 x 53 Argentine" : {
     "name" : "7.65 x 53 Argentine",
     "names" : [ "7.65 x 53 Arg." ],
     "specs" : {
-      "coal_mm" : 76.0,
-      "coal_inch" : 2.9921276
+      "coal_mm" : "76.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page50.pdf" ],
-    "diameter_mm" : 7.94,
-    "diameter_inch" : 0.312598594
+    "diameter_mm" : "7.94"
   },
   "7.82 Warbird" : {
     "name" : "7.82 Warbird",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 92.2,
-      "coal_inch" : 3.62992322
+      "coal_mm" : "92.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page51.pdf" ],
-    "diameter_mm" : 7.84,
-    "diameter_inch" : 0.308661584
+    "diameter_mm" : "7.84"
   },
   "7.92 x 24 Van Bruaene Rik" : {
     "name" : "7.92 x 24 Van Bruaene Rik",
     "names" : [ "7.92 x 24 VBR" ],
     "specs" : {
-      "coal_mm" : 32.1,
-      "coal_inch" : 1.26378021
+      "coal_mm" : "32.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page52.pdf" ],
-    "diameter_mm" : 7.92,
-    "diameter_inch" : 0.31181119199999996
+    "diameter_mm" : "7.92"
   },
   "7.92 x 33 kurz" : {
     "name" : "7.92 x 33 kurz",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 48.0,
-      "coal_inch" : 1.8897648
+      "coal_mm" : "48.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-92-x-33-kurz-en.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "700 Holland & Holland Nitro Express" : {
     "name" : "700 Holland & Holland Nitro Express",
     "names" : [ "700 H&H Nitro Exp." ],
     "specs" : {
-      "coal_mm" : 106.68,
-      "coal_inch" : 4.200002268
+      "coal_mm" : "106.68"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page131.pdf" ],
-    "diameter_mm" : 17.78,
-    "diameter_inch" : 0.700000378
+    "diameter_mm" : "17.78"
   },
   "7mm - 08 Remington" : {
     "name" : "7mm - 08 Remington",
     "names" : [ "7 mm - 08 Rem." ],
     "specs" : {
-      "coal_mm" : 71.12,
-      "coal_inch" : 2.800001512
+      "coal_mm" : "71.12"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page35.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7mm Bench Rest Remington" : {
     "name" : "7mm Bench Rest Remington",
     "names" : [ "7 mm B.R. Rem." ],
     "specs" : {
-      "coal_mm" : 54.42,
-      "coal_inch" : 2.142520842
+      "coal_mm" : "54.42"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page37.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7mm Blaser Magnum" : {
     "name" : "7mm Blaser Magnum",
     "names" : [ "7 mm Blaser Mag." ],
     "specs" : {
-      "coal_mm" : 80.0,
-      "coal_inch" : 3.1496079999999997
+      "coal_mm" : "80.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page36.pdf" ],
-    "diameter_mm" : 7.22,
-    "diameter_inch" : 0.284252122
+    "diameter_mm" : "7.22"
   },
   "7mm Express Remington" : {
     "name" : "7mm Express Remington",
     "names" : [ "7 mm Exp. Rem." ],
     "specs" : {
-      "coal_mm" : 84.58,
-      "coal_inch" : 3.329923058
+      "coal_mm" : "84.58"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page38.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7mm KM" : {
     "name" : "7mm KM",
     "names" : [ "7 mm KM" ],
     "specs" : {
-      "coal_mm" : 93.5,
-      "coal_inch" : 3.68110435
+      "coal_mm" : "93.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-mm-km-en.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7mm Magnum Flanged Holland & Holland" : {
     "name" : "7mm Magnum Flanged Holland & Holland",
     "names" : [ "7 mm Mag.Fl. H&H" ],
     "specs" : {
-      "coal_mm" : 82.8,
-      "coal_inch" : 3.25984428
+      "coal_mm" : "82.8"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page23.pdf" ],
-    "diameter_mm" : 7.21,
-    "diameter_inch" : 0.28385842099999997
+    "diameter_mm" : "7.21"
   },
   "7mm Remington Magnum" : {
     "name" : "7mm Remington Magnum",
     "names" : [ "7 mm Rem. Mag." ],
     "specs" : {
-      "coal_mm" : 83.57,
-      "coal_inch" : 3.2901592569999996
+      "coal_mm" : "83.57"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page3.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7mm Remington Short Action Ultra Magnum" : {
     "name" : "7mm Remington Short Action Ultra Magnum",
     "names" : [ "7 mm Rem. SA Ultra Mag." ],
     "specs" : {
-      "coal_mm" : 71.76,
-      "coal_inch" : 2.825198376
+      "coal_mm" : "71.76"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page40.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7mm Remington Ultra Magnum" : {
     "name" : "7mm Remington Ultra Magnum",
     "names" : [ "7 mm Rem. Ultra Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page41.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7mm Rosè" : {
     "name" : "7mm Rosè",
     "names" : [ "7 mm Rosè" ],
     "specs" : {
-      "coal_mm" : 83.57,
-      "coal_inch" : 3.2901592569999996
+      "coal_mm" : "83.57"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/7-mm-rose-170223-en.pdf" ],
-    "diameter_mm" : 7.22,
-    "diameter_inch" : 0.284252122
+    "diameter_mm" : "7.22"
   },
   "7mm Shooting Times Westerner" : {
     "name" : "7mm Shooting Times Westerner",
     "names" : [ "7 mm STW" ],
     "specs" : {
-      "coal_mm" : 92.71,
-      "coal_inch" : 3.6500019709999996
+      "coal_mm" : "92.71"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page4.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "7mm Super Express Vom Hofe" : {
     "name" : "7mm Super Express Vom Hofe",
     "names" : [ "7 mm SE v.H." ],
     "specs" : {
-      "coal_mm" : 84.0,
-      "coal_inch" : 3.3070884
+      "coal_mm" : "84.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page42.pdf" ],
-    "diameter_mm" : 7.24,
-    "diameter_inch" : 0.285039524
+    "diameter_mm" : "7.24"
   },
   "7mm Weatherby Magnum" : {
     "name" : "7mm Weatherby Magnum",
     "names" : [ "7 mm Weath. Mag." ],
     "specs" : {
-      "coal_mm" : 85.34,
-      "coal_inch" : 3.359844334
+      "coal_mm" : "85.34"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page5.pdf" ],
-    "diameter_mm" : 7.22,
-    "diameter_inch" : 0.284252122
+    "diameter_mm" : "7.22"
   },
   "7mm Winchester Short Magnum" : {
     "name" : "7mm Winchester Short Magnum",
     "names" : [ "7 mm Win. Short Mag." ],
     "specs" : {
-      "coal_mm" : 72.64,
-      "coal_inch" : 2.859844064
+      "coal_mm" : "72.64"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/7-mm-win-short-mag-en.pdf" ],
-    "diameter_mm" : 7.23,
-    "diameter_inch" : 0.284645823
+    "diameter_mm" : "7.23"
   },
   "8 x 50 R" : {
     "name" : "8 x 50 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 76.0,
-      "coal_inch" : 2.9921276
+      "coal_mm" : "76.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page30.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8 x 51 (Mauser K)" : {
     "name" : "8 x 51 (Mauser K)",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 68.0,
-      "coal_inch" : 2.6771667999999997
+      "coal_mm" : "68.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page54.pdf" ],
-    "diameter_mm" : 8.07,
-    "diameter_inch" : 0.317716707
+    "diameter_mm" : "8.07"
   },
   "8 x 51 R Lebel" : {
     "name" : "8 x 51 R Lebel",
@@ -3855,157 +3219,131 @@
     "name" : "8 x 56 Mannlicher–Schönauer",
     "names" : [ "8 x 56 M.-Sch." ],
     "specs" : {
-      "coal_mm" : 77.8,
-      "coal_inch" : 3.0629937799999998
+      "coal_mm" : "77.8"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page55.pdf" ],
-    "diameter_mm" : 8.25,
-    "diameter_inch" : 0.324803325
+    "diameter_mm" : "8.25"
   },
   "8 x 56 R M30S" : {
     "name" : "8 x 56 R M30S",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 76.5,
-      "coal_inch" : 3.01181265
+      "coal_mm" : "76.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page31.pdf" ],
-    "diameter_mm" : 8.4,
-    "diameter_inch" : 0.33070884
+    "diameter_mm" : "8.4"
   },
   "8 x 56 R M89 Portuguese Kropatschek" : {
     "name" : "8 x 56 R M89 Portuguese Kropatschek",
     "names" : [ "8 x 56 R M89 Port. Krop." ],
     "specs" : {
-      "coal_mm" : 81.0,
-      "coal_inch" : 3.1889781
+      "coal_mm" : "81.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page32.pdf" ],
-    "diameter_mm" : 8.2,
-    "diameter_inch" : 0.32283481999999997
+    "diameter_mm" : "8.2"
   },
   "8 x 57 I" : {
     "name" : "8 x 57 I",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page56.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 57 IR" : {
     "name" : "8 x 57 IR",
     "names" : [ "8 x 57 JR" ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/8-x-57-ir-en.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 57 IRS" : {
     "name" : "8 x 57 IRS",
     "names" : [ "8 x 57 JRS" ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/8-x-57-irs-en.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8 x 57 IS" : {
     "name" : "8 x 57 IS",
     "names" : [ "8 x 57 JS" ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/8-x-57-is-en.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8 x 57 PCC" : {
     "name" : "8 x 57 PCC",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page58.pdf" ],
-    "diameter_mm" : 8.2,
-    "diameter_inch" : 0.32283481999999997
+    "diameter_mm" : "8.2"
   },
   "8 x 57 R 360" : {
     "name" : "8 x 57 R 360",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 77.0,
-      "coal_inch" : 3.0314977
+      "coal_mm" : "77.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page33.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 58 R" : {
     "name" : "8 x 58 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 78.0,
-      "coal_inch" : 3.0708678
+      "coal_mm" : "78.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page36.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 60" : {
     "name" : "8 x 60",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/8-x-60-en.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 60 R" : {
     "name" : "8 x 60 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page37.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 60 RS" : {
     "name" : "8 x 60 RS",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 83.6,
-      "coal_inch" : 3.2913403599999995
+      "coal_mm" : "83.6"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page38.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8 x 60 S" : {
     "name" : "8 x 60 S",
@@ -4018,372 +3356,310 @@
     "name" : "8 x 64",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 86.0,
-      "coal_inch" : 3.3858286
+      "coal_mm" : "86.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page61.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 64 S" : {
     "name" : "8 x 64 S",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.5,
-      "coal_inch" : 3.44488375
+      "coal_mm" : "87.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page62.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8 x 65 R" : {
     "name" : "8 x 65 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 86.0,
-      "coal_inch" : 3.3858286
+      "coal_mm" : "86.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page39.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 65 RS" : {
     "name" : "8 x 65 RS",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.5,
-      "coal_inch" : 3.44488375
+      "coal_mm" : "87.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page40.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8 x 68 S" : {
     "name" : "8 x 68 S",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.0,
-      "coal_inch" : 3.4251986999999997
+      "coal_mm" : "87.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page63.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8 x 72 R" : {
     "name" : "8 x 72 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 98.0,
-      "coal_inch" : 3.8582698
+      "coal_mm" : "98.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page41.pdf" ],
-    "diameter_mm" : 8.09,
-    "diameter_inch" : 0.318504109
+    "diameter_mm" : "8.09"
   },
   "8 x 75 RS" : {
     "name" : "8 x 75 RS",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 96.0,
-      "coal_inch" : 3.7795296
+      "coal_mm" : "96.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page42.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8 x 75 S" : {
     "name" : "8 x 75 S",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 96.0,
-      "coal_inch" : 3.7795296
+      "coal_mm" : "96.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page64.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8.15 x 46 R" : {
     "name" : "8.15 x 46 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 62.3,
-      "coal_inch" : 2.4527572299999996
+      "coal_mm" : "62.3"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page44.pdf" ],
-    "diameter_mm" : 8.38,
-    "diameter_inch" : 0.329921438
+    "diameter_mm" : "8.38"
   },
   "8.2 x 53 R" : {
     "name" : "8.2 x 53 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 76.0,
-      "coal_inch" : 2.9921276
+      "coal_mm" : "76.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page45.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8.5 x 63" : {
     "name" : "8.5 x 63",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.0,
-      "coal_inch" : 3.3070884
+      "coal_mm" : "84.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page65.pdf" ],
-    "diameter_mm" : 8.61,
-    "diameter_inch" : 0.33897656099999995
+    "diameter_mm" : "8.61"
   },
   "8.5 x 63 R" : {
     "name" : "8.5 x 63 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 84.0,
-      "coal_inch" : 3.3070884
+      "coal_mm" : "84.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page46.pdf" ],
-    "diameter_mm" : 8.59,
-    "diameter_inch" : 0.33818915899999996
+    "diameter_mm" : "8.59"
   },
   "8.5 x 68 Fanzoj" : {
     "name" : "8.5 x 68 Fanzoj",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 87.0,
-      "coal_inch" : 3.4251986999999997
+      "coal_mm" : "87.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/8-5-x-68-fanzoj-en.pdf" ],
-    "diameter_mm" : 8.59,
-    "diameter_inch" : 0.33818915899999996
+    "diameter_mm" : "8.59"
   },
   "8.5 x 75 R Scheiring" : {
     "name" : "8.5 x 75 R Scheiring",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 96.0,
-      "coal_inch" : 3.7795296
+      "coal_mm" : "96.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/8-5-x-75-r-scheiring-en.pdf" ],
-    "diameter_mm" : 8.61,
-    "diameter_inch" : 0.33897656099999995
+    "diameter_mm" : "8.61"
   },
   "8.5mm Messner Magnum" : {
     "name" : "8.5mm Messner Magnum",
     "names" : [ "8.5 mm Messner Mag." ],
     "specs" : {
-      "coal_mm" : 88.0,
-      "coal_inch" : 3.4645688
+      "coal_mm" : "88.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/8-5-mm-messner-mag-en.pdf" ],
-    "diameter_mm" : 8.59,
-    "diameter_inch" : 0.33818915899999996
+    "diameter_mm" : "8.59"
   },
   "8mm Remington Magnum" : {
     "name" : "8mm Remington Magnum",
     "names" : [ "8 mm Rem.Mag." ],
     "specs" : {
-      "coal_mm" : 91.44,
-      "coal_inch" : 3.6000019439999997
+      "coal_mm" : "91.44"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-iii/tabiiical-en-page6.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "8mm – 348 Winchester" : {
     "name" : "8mm – 348 Winchester",
     "names" : [ "8 mm – 348 Win." ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page43.pdf" ],
-    "diameter_mm" : 8.22,
-    "diameter_inch" : 0.323622222
+    "diameter_mm" : "8.22"
   },
   "9 x 53 R" : {
     "name" : "9 x 53 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 67.0,
-      "coal_inch" : 2.6377967
+      "coal_mm" : "67.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page47.pdf" ],
-    "diameter_mm" : 9.27,
-    "diameter_inch" : 0.364960827
+    "diameter_mm" : "9.27"
   },
   "9 x 56 Mannlicher–Schönauer" : {
     "name" : "9 x 56 Mannlicher–Schönauer",
     "names" : [ "9 x 56 M.-Sch." ],
     "specs" : {
-      "coal_mm" : 81.0,
-      "coal_inch" : 3.1889781
+      "coal_mm" : "81.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page66.pdf" ],
-    "diameter_mm" : 9.08,
-    "diameter_inch" : 0.357480508
+    "diameter_mm" : "9.08"
   },
   "9 x 57" : {
     "name" : "9 x 57",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 81.0,
-      "coal_inch" : 3.1889781
+      "coal_mm" : "81.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page67.pdf" ],
-    "diameter_mm" : 9.08,
-    "diameter_inch" : 0.357480508
+    "diameter_mm" : "9.08"
   },
   "9 x 57 R" : {
     "name" : "9 x 57 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 81.0,
-      "coal_inch" : 3.1889781
+      "coal_mm" : "81.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page48.pdf" ],
-    "diameter_mm" : 9.08,
-    "diameter_inch" : 0.357480508
+    "diameter_mm" : "9.08"
   },
   "9.3 Roedale Short Magnum" : {
     "name" : "9.3 Roedale Short Magnum",
     "names" : [ "9.3 RSM" ],
     "specs" : {
-      "coal_mm" : 75.0,
-      "coal_inch" : 2.9527574999999997
+      "coal_mm" : "75.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/9-3-rsm-en.pdf" ],
-    "diameter_mm" : 9.3,
-    "diameter_inch" : 0.36614193
+    "diameter_mm" : "9.3"
   },
   "9.3 x 53 R Finnish" : {
     "name" : "9.3 x 53 R Finnish",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 76.0,
-      "coal_inch" : 2.9921276
+      "coal_mm" : "76.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page49.pdf" ],
-    "diameter_mm" : 9.3,
-    "diameter_inch" : 0.36614193
+    "diameter_mm" : "9.3"
   },
   "9.3 x 57" : {
     "name" : "9.3 x 57",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 82.0,
-      "coal_inch" : 3.2283481999999997
+      "coal_mm" : "82.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/9-3-x-57-en.pdf" ],
-    "diameter_mm" : 9.3,
-    "diameter_inch" : 0.36614193
+    "diameter_mm" : "9.3"
   },
   "9.3 x 62" : {
     "name" : "9.3 x 62",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 83.6,
-      "coal_inch" : 3.2913403599999995
+      "coal_mm" : "83.6"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page69.pdf" ],
-    "diameter_mm" : 9.3,
-    "diameter_inch" : 0.36614193
+    "diameter_mm" : "9.3"
   },
   "9.3 x 64 Brenneke" : {
     "name" : "9.3 x 64 Brenneke",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 85.6,
-      "coal_inch" : 3.3700805599999994
+      "coal_mm" : "85.6"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page70.pdf" ],
-    "diameter_mm" : 9.3,
-    "diameter_inch" : 0.36614193
+    "diameter_mm" : "9.3"
   },
   "9.3 x 66 Sako" : {
     "name" : "9.3 x 66 Sako",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 85.0,
-      "coal_inch" : 3.3464585
+      "coal_mm" : "85.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page71.pdf" ],
-    "diameter_mm" : 9.3,
-    "diameter_inch" : 0.36614193
+    "diameter_mm" : "9.3"
   },
   "9.3 x 72 R" : {
     "name" : "9.3 x 72 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 86.0,
-      "coal_inch" : 3.3858286
+      "coal_mm" : "86.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page50.pdf" ],
-    "diameter_mm" : 9.57,
-    "diameter_inch" : 0.376771857
+    "diameter_mm" : "9.57"
   },
   "9.3 x 74 R" : {
     "name" : "9.3 x 74 R",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 96.5,
-      "coal_inch" : 3.7992146499999997
+      "coal_mm" : "96.5"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/9-3-x-74-r-en.pdf" ],
-    "diameter_mm" : 9.3,
-    "diameter_inch" : 0.36614193
+    "diameter_mm" : "9.3"
   },
   "9.5 x 57 Mannlicher–Schönauer" : {
     "name" : "9.5 x 57 Mannlicher–Schönauer",
     "names" : [ "9.5 x 57 M.-Sch." ],
     "specs" : {
-      "coal_mm" : 75.0,
-      "coal_inch" : 2.9527574999999997
+      "coal_mm" : "75.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page72.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   },
   "9.5 x 66 Super Express Vom Hofe" : {
     "name" : "9.5 x 66 Super Express Vom Hofe",
     "names" : [ "9.5 x 66 SE v. H." ],
     "specs" : {
-      "coal_mm" : 85.0,
-      "coal_inch" : 3.3464585
+      "coal_mm" : "85.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page73.pdf" ],
-    "diameter_mm" : 9.55,
-    "diameter_inch" : 0.375984455
+    "diameter_mm" : "9.55"
   }
 }

--- a/data/rimfire/cip.json
+++ b/data/rimfire/cip.json
@@ -1,30 +1,338 @@
 {
-    "4mm Randz. court": {},
-    "4mm Randz. long": {},
-    "5mm Remington Magnum": {},
-    "5.6mm (22) Flobert à balle": {},
-    "5.6mm Flobert à plombs SC": {},
-    "5.6mm Flobert à plombs DC": {},
-    "6mm Flobert à balle": {},
-    "6mm Flobert à balle DC": {},
-    "6mm ME Flobert court": {},
-    "9mm Flobert à balle": {},
-    "9mm Flobert à plombs Carton": {},
-    "9mm Flobert à plombs Metal": {},
-    "22 Bulleted Breech Cap": {},
-    "22 Conical Ball Cap": {},
-    "22 Long": {},
-    "22 Extra Long": {},
-    "22 Extra L.R.": {},
-    "22 Long Shot": {},
-    "22 Long Rifle Shot Claybirding": {},
-    "22 Remington Automatic": {},
-    "22 Winchester Automatic": {},
-    "22 Winchester Magnum Rimfire et 22 Remington Special": {},
-    "17 Hornady Magnum Rimfire": {},
-    "17 Mach 2": {},
-    "17 Winchester Super Magnum": {},
-    "22 Long Rifle": {},
-    "22 Short": {},
-    "22 Winchester Magnum Rimfire": {}
+  "17 Hornady Magnum Rimfire" : {
+    "name" : "17 Hornady Magnum Rimfire",
+    "names" : [ "17 HMR" ],
+    "specs" : {
+      "coal_mm" : 34.67,
+      "coal_inch" : 1.364961367
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/17-hmr-en.pdf" ],
+    "diameter_mm" : 4.38,
+    "diameter_inch" : 0.172441038
+  },
+  "17 Mach 2" : {
+    "name" : "17 Mach 2",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 25.4,
+      "coal_inch" : 1.0000005399999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/17-mach-2-en-1.pdf" ],
+    "diameter_mm" : 4.38,
+    "diameter_inch" : 0.172441038
+  },
+  "17 Winchester Super Magnum" : {
+    "name" : "17 Winchester Super Magnum",
+    "names" : [ "17 Win. Super Mag.", "17 Winchester Short Magnum", "17 WSM" ],
+    "specs" : {
+      "coal_mm" : 40.39,
+      "coal_inch" : 1.590158339
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/17-wsm-en.pdf" ],
+    "diameter_mm" : 4.38,
+    "diameter_inch" : 0.172441038
+  },
+  "22 Bulleted Breech Cap" : {
+    "name" : "22 Bulleted Breech Cap",
+    "names" : [ "22 BB Cap" ],
+    "specs" : {
+      "coal_mm" : 11.18,
+      "coal_inch" : 0.440157718
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-bb-cap-en.pdf" ],
+    "diameter_mm" : 5.72,
+    "diameter_inch" : 0.22519697199999997
+  },
+  "22 Conical Ball Cap" : {
+    "name" : "22 Conical Ball Cap",
+    "names" : [ "22 CB Cap" ],
+    "specs" : {
+      "coal_mm" : 13.72,
+      "coal_inch" : 0.540157772
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-cb-cap-en.pdf" ],
+    "diameter_mm" : 5.72,
+    "diameter_inch" : 0.22519697199999997
+  },
+  "22 Extra L.R." : {
+    "name" : "22 Extra L.R.",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 25.4,
+      "coal_inch" : 1.0000005399999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-extra-lr-en.pdf" ],
+    "diameter_mm" : 5.73,
+    "diameter_inch" : 0.22559067300000002
+  },
+  "22 Extra Long" : {
+    "name" : "22 Extra Long",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 28.1,
+      "coal_inch" : 1.10629981
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-extra-long-en.pdf" ],
+    "diameter_mm" : 5.72,
+    "diameter_inch" : 0.22519697199999997
+  },
+  "22 Long" : {
+    "name" : "22 Long",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 22.56,
+      "coal_inch" : 0.8881894559999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-long-en.pdf" ],
+    "diameter_mm" : 5.72,
+    "diameter_inch" : 0.22519697199999997
+  },
+  "22 Long Rifle" : {
+    "name" : "22 Long Rifle",
+    "names" : [ "22 l.r.,22 lang für Büchsen", "22 lfB" ],
+    "specs" : {
+      "coal_mm" : 25.4,
+      "coal_inch" : 1.0000005399999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-long-rifle-en.pdf" ],
+    "diameter_mm" : 5.72,
+    "diameter_inch" : 0.22519697199999997
+  },
+  "22 Long Rifle Shot Claybirding" : {
+    "name" : "22 Long Rifle Shot Claybirding",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 25.15,
+      "coal_inch" : 0.9901580149999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-long-rifle-shot-claybirding-en.pdf" ],
+    "diameter_mm" : 5.51,
+    "diameter_inch" : 0.216929251
+  },
+  "22 Long Shot" : {
+    "name" : "22 Long Shot",
+    "names" : [ ],
+    "specs" : {
+      "coal_mm" : 22.38,
+      "coal_inch" : 0.8811028379999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-long-shot-en.pdf" ],
+    "diameter_mm" : 5.51,
+    "diameter_inch" : 0.216929251
+  },
+  "22 Remington Automatic" : {
+    "name" : "22 Remington Automatic",
+    "names" : [ "22 Rem. Auto" ],
+    "specs" : {
+      "coal_mm" : 23.95,
+      "coal_inch" : 0.9429138949999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-rem-auto-en.pdf" ],
+    "diameter_mm" : 5.8,
+    "diameter_inch" : 0.22834658
+  },
+  "22 Short" : {
+    "name" : "22 Short",
+    "names" : [ "22 kurz", "22 court" ],
+    "specs" : {
+      "coal_mm" : 17.65,
+      "coal_inch" : 0.6948822649999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-short-en.pdf" ],
+    "diameter_mm" : 5.72,
+    "diameter_inch" : 0.22519697199999997
+  },
+  "22 Winchester Automatic" : {
+    "name" : "22 Winchester Automatic",
+    "names" : [ "22 Win. Auto" ],
+    "specs" : {
+      "coal_mm" : 23.24,
+      "coal_inch" : 0.9149611239999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-win-auto-en.pdf" ],
+    "diameter_mm" : 5.78,
+    "diameter_inch" : 0.227559178
+  },
+  "22 Winchester Magnum Rimfire" : {
+    "name" : "22 Winchester Magnum Rimfire",
+    "names" : [ "22 Win.Mag.,22 WMR", "22 Magnum", "22 Win. Mag. R.F." ],
+    "specs" : {
+      "coal_mm" : 34.29,
+      "coal_inch" : 1.350000729
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-win-mag-rf-en.pdf" ],
+    "diameter_mm" : 5.7,
+    "diameter_inch" : 0.22440957
+  },
+  "22 Winchester Magnum Rimfire et 22 Remington Special" : {
+    "name" : "22 Winchester Magnum Rimfire et 22 Remington Special",
+    "names" : [ "22 Win. R.F. et 22 Rem.Spl." ],
+    "specs" : {
+      "coal_mm" : 29.97,
+      "coal_inch" : 1.1799218969999998
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-win-rf-et-22-rem-spl-en.pdf" ],
+    "diameter_mm" : 5.8,
+    "diameter_inch" : 0.22834658
+  },
+  "4mm Randz. court" : {
+    "name" : "4mm Randz. court",
+    "names" : [ "4 mm Randz. court" ],
+    "specs" : {
+      "coal_mm" : 9.2,
+      "coal_inch" : 0.36220491999999993
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page1.pdf" ],
+    "diameter_mm" : 4.4,
+    "diameter_inch" : 0.17322844
+  },
+  "4mm Randz. long" : {
+    "name" : "4mm Randz. long",
+    "names" : [ "4 mm Randz. long" ],
+    "specs" : {
+      "coal_mm" : 11.2,
+      "coal_inch" : 0.44094511999999997
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page2.pdf" ],
+    "diameter_mm" : 4.4,
+    "diameter_inch" : 0.17322844
+  },
+  "5.6mm (22) Flobert à balle" : {
+    "name" : "5.6mm (22) Flobert à balle",
+    "names" : [ "5.6 mm (22) Flobert à balle" ],
+    "specs" : {
+      "coal_mm" : 12.7,
+      "coal_inch" : 0.5000002699999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page4.pdf" ],
+    "diameter_mm" : 5.71,
+    "diameter_inch" : 0.224803271
+  },
+  "5.6mm Flobert à plombs DC" : {
+    "name" : "5.6mm Flobert à plombs DC",
+    "names" : [ "5.6 mm Flobert à plombs DC" ],
+    "specs" : {
+      "coal_mm" : 32.1,
+      "coal_inch" : 1.26378021
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page6.pdf" ],
+    "diameter_mm" : 5.73,
+    "diameter_inch" : 0.22559067300000002
+  },
+  "5.6mm Flobert à plombs SC" : {
+    "name" : "5.6mm Flobert à plombs SC",
+    "names" : [ "5.6 mm Flobert à plombs SC" ],
+    "specs" : {
+      "coal_mm" : 22.1,
+      "coal_inch" : 0.87007921
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page5.pdf" ],
+    "diameter_mm" : 5.73,
+    "diameter_inch" : 0.22559067300000002
+  },
+  "5mm Remington Magnum" : {
+    "name" : "5mm Remington Magnum",
+    "names" : [ "5 mm Rem.Mag." ],
+    "specs" : {
+      "coal_mm" : 32.89,
+      "coal_inch" : 1.294882589
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page3.pdf" ],
+    "diameter_mm" : 5.21,
+    "diameter_inch" : 0.205118221
+  },
+  "6mm Flobert à balle" : {
+    "name" : "6mm Flobert à balle",
+    "names" : [ "6 mm Flobert à balle" ],
+    "specs" : {
+      "coal_mm" : 12.7,
+      "coal_inch" : 0.5000002699999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page7.pdf" ],
+    "diameter_mm" : 5.87,
+    "diameter_inch" : 0.231102487
+  },
+  "6mm Flobert à balle DC" : {
+    "name" : "6mm Flobert à balle DC",
+    "names" : [ "6 mm Flobert à balle DC" ],
+    "specs" : {
+      "coal_mm" : 12.7,
+      "coal_inch" : 0.5000002699999999
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page8.pdf" ],
+    "diameter_mm" : 5.87,
+    "diameter_inch" : 0.231102487
+  },
+  "6mm ME Flobert court" : {
+    "name" : "6mm ME Flobert court",
+    "names" : [ "6 mm ME Flobert court" ],
+    "specs" : {
+      "coal_mm" : 9.2,
+      "coal_inch" : 0.36220491999999993
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/6mm-me-flobert-court-en.pdf" ],
+    "diameter_mm" : 5.65,
+    "diameter_inch" : 0.222441065
+  },
+  "9mm Flobert à balle" : {
+    "name" : "9mm Flobert à balle",
+    "names" : [ "9 mm Flobert à balle" ],
+    "specs" : {
+      "coal_mm" : 18.1,
+      "coal_inch" : 0.71259881
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page10.pdf" ],
+    "diameter_mm" : 8.8,
+    "diameter_inch" : 0.34645688
+  },
+  "9mm Flobert à plombs Carton" : {
+    "name" : "9mm Flobert à plombs Carton",
+    "names" : [ "9 mm Flobert à plombs Carton" ],
+    "specs" : {
+      "coal_mm" : 45.0,
+      "coal_inch" : 1.7716545
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page11.pdf" ],
+    "diameter_mm" : 8.8,
+    "diameter_inch" : 0.34645688
+  },
+  "9mm Flobert à plombs Metal" : {
+    "name" : "9mm Flobert à plombs Metal",
+    "names" : [ "9 mm Flobert à plombs Metal" ],
+    "specs" : {
+      "coal_mm" : 45.0,
+      "coal_inch" : 1.7716545
+    },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page12.pdf" ],
+    "diameter_mm" : 8.8,
+    "diameter_inch" : 0.34645688
+  }
 }

--- a/data/rimfire/cip.json
+++ b/data/rimfire/cip.json
@@ -3,336 +3,280 @@
     "name" : "17 Hornady Magnum Rimfire",
     "names" : [ "17 HMR" ],
     "specs" : {
-      "coal_mm" : 34.67,
-      "coal_inch" : 1.364961367
+      "coal_mm" : "34.67"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/17-hmr-en.pdf" ],
-    "diameter_mm" : 4.38,
-    "diameter_inch" : 0.172441038
+    "diameter_mm" : "4.38"
   },
   "17 Mach 2" : {
     "name" : "17 Mach 2",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 25.4,
-      "coal_inch" : 1.0000005399999998
+      "coal_mm" : "25.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/17-mach-2-en-1.pdf" ],
-    "diameter_mm" : 4.38,
-    "diameter_inch" : 0.172441038
+    "diameter_mm" : "4.38"
   },
   "17 Winchester Super Magnum" : {
     "name" : "17 Winchester Super Magnum",
     "names" : [ "17 Win. Super Mag.", "17 Winchester Short Magnum", "17 WSM" ],
     "specs" : {
-      "coal_mm" : 40.39,
-      "coal_inch" : 1.590158339
+      "coal_mm" : "40.39"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/17-wsm-en.pdf" ],
-    "diameter_mm" : 4.38,
-    "diameter_inch" : 0.172441038
+    "diameter_mm" : "4.38"
   },
   "22 Bulleted Breech Cap" : {
     "name" : "22 Bulleted Breech Cap",
     "names" : [ "22 BB Cap" ],
     "specs" : {
-      "coal_mm" : 11.18,
-      "coal_inch" : 0.440157718
+      "coal_mm" : "11.18"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-bb-cap-en.pdf" ],
-    "diameter_mm" : 5.72,
-    "diameter_inch" : 0.22519697199999997
+    "diameter_mm" : "5.72"
   },
   "22 Conical Ball Cap" : {
     "name" : "22 Conical Ball Cap",
     "names" : [ "22 CB Cap" ],
     "specs" : {
-      "coal_mm" : 13.72,
-      "coal_inch" : 0.540157772
+      "coal_mm" : "13.72"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-cb-cap-en.pdf" ],
-    "diameter_mm" : 5.72,
-    "diameter_inch" : 0.22519697199999997
+    "diameter_mm" : "5.72"
   },
   "22 Extra L.R." : {
     "name" : "22 Extra L.R.",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 25.4,
-      "coal_inch" : 1.0000005399999998
+      "coal_mm" : "25.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-extra-lr-en.pdf" ],
-    "diameter_mm" : 5.73,
-    "diameter_inch" : 0.22559067300000002
+    "diameter_mm" : "5.73"
   },
   "22 Extra Long" : {
     "name" : "22 Extra Long",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 28.1,
-      "coal_inch" : 1.10629981
+      "coal_mm" : "28.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-extra-long-en.pdf" ],
-    "diameter_mm" : 5.72,
-    "diameter_inch" : 0.22519697199999997
+    "diameter_mm" : "5.72"
   },
   "22 Long" : {
     "name" : "22 Long",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 22.56,
-      "coal_inch" : 0.8881894559999999
+      "coal_mm" : "22.56"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-long-en.pdf" ],
-    "diameter_mm" : 5.72,
-    "diameter_inch" : 0.22519697199999997
+    "diameter_mm" : "5.72"
   },
   "22 Long Rifle" : {
     "name" : "22 Long Rifle",
     "names" : [ "22 l.r.,22 lang für Büchsen", "22 lfB" ],
     "specs" : {
-      "coal_mm" : 25.4,
-      "coal_inch" : 1.0000005399999998
+      "coal_mm" : "25.4"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-long-rifle-en.pdf" ],
-    "diameter_mm" : 5.72,
-    "diameter_inch" : 0.22519697199999997
+    "diameter_mm" : "5.72"
   },
   "22 Long Rifle Shot Claybirding" : {
     "name" : "22 Long Rifle Shot Claybirding",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 25.15,
-      "coal_inch" : 0.9901580149999999
+      "coal_mm" : "25.15"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-long-rifle-shot-claybirding-en.pdf" ],
-    "diameter_mm" : 5.51,
-    "diameter_inch" : 0.216929251
+    "diameter_mm" : "5.51"
   },
   "22 Long Shot" : {
     "name" : "22 Long Shot",
     "names" : [ ],
     "specs" : {
-      "coal_mm" : 22.38,
-      "coal_inch" : 0.8811028379999999
+      "coal_mm" : "22.38"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-long-shot-en.pdf" ],
-    "diameter_mm" : 5.51,
-    "diameter_inch" : 0.216929251
+    "diameter_mm" : "5.51"
   },
   "22 Remington Automatic" : {
     "name" : "22 Remington Automatic",
     "names" : [ "22 Rem. Auto" ],
     "specs" : {
-      "coal_mm" : 23.95,
-      "coal_inch" : 0.9429138949999999
+      "coal_mm" : "23.95"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-rem-auto-en.pdf" ],
-    "diameter_mm" : 5.8,
-    "diameter_inch" : 0.22834658
+    "diameter_mm" : "5.8"
   },
   "22 Short" : {
     "name" : "22 Short",
     "names" : [ "22 kurz", "22 court" ],
     "specs" : {
-      "coal_mm" : 17.65,
-      "coal_inch" : 0.6948822649999999
+      "coal_mm" : "17.65"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-short-en.pdf" ],
-    "diameter_mm" : 5.72,
-    "diameter_inch" : 0.22519697199999997
+    "diameter_mm" : "5.72"
   },
   "22 Winchester Automatic" : {
     "name" : "22 Winchester Automatic",
     "names" : [ "22 Win. Auto" ],
     "specs" : {
-      "coal_mm" : 23.24,
-      "coal_inch" : 0.9149611239999998
+      "coal_mm" : "23.24"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-win-auto-en.pdf" ],
-    "diameter_mm" : 5.78,
-    "diameter_inch" : 0.227559178
+    "diameter_mm" : "5.78"
   },
   "22 Winchester Magnum Rimfire" : {
     "name" : "22 Winchester Magnum Rimfire",
     "names" : [ "22 Win.Mag.,22 WMR", "22 Magnum", "22 Win. Mag. R.F." ],
     "specs" : {
-      "coal_mm" : 34.29,
-      "coal_inch" : 1.350000729
+      "coal_mm" : "34.29"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-win-mag-rf-en.pdf" ],
-    "diameter_mm" : 5.7,
-    "diameter_inch" : 0.22440957
+    "diameter_mm" : "5.7"
   },
   "22 Winchester Magnum Rimfire et 22 Remington Special" : {
     "name" : "22 Winchester Magnum Rimfire et 22 Remington Special",
     "names" : [ "22 Win. R.F. et 22 Rem.Spl." ],
     "specs" : {
-      "coal_mm" : 29.97,
-      "coal_inch" : 1.1799218969999998
+      "coal_mm" : "29.97"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/22-win-rf-et-22-rem-spl-en.pdf" ],
-    "diameter_mm" : 5.8,
-    "diameter_inch" : 0.22834658
+    "diameter_mm" : "5.8"
   },
   "4mm Randz. court" : {
     "name" : "4mm Randz. court",
     "names" : [ "4 mm Randz. court" ],
     "specs" : {
-      "coal_mm" : 9.2,
-      "coal_inch" : 0.36220491999999993
+      "coal_mm" : "9.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page1.pdf" ],
-    "diameter_mm" : 4.4,
-    "diameter_inch" : 0.17322844
+    "diameter_mm" : "4.4"
   },
   "4mm Randz. long" : {
     "name" : "4mm Randz. long",
     "names" : [ "4 mm Randz. long" ],
     "specs" : {
-      "coal_mm" : 11.2,
-      "coal_inch" : 0.44094511999999997
+      "coal_mm" : "11.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page2.pdf" ],
-    "diameter_mm" : 4.4,
-    "diameter_inch" : 0.17322844
+    "diameter_mm" : "4.4"
   },
   "5.6mm (22) Flobert à balle" : {
     "name" : "5.6mm (22) Flobert à balle",
     "names" : [ "5.6 mm (22) Flobert à balle" ],
     "specs" : {
-      "coal_mm" : 12.7,
-      "coal_inch" : 0.5000002699999999
+      "coal_mm" : "12.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page4.pdf" ],
-    "diameter_mm" : 5.71,
-    "diameter_inch" : 0.224803271
+    "diameter_mm" : "5.71"
   },
   "5.6mm Flobert à plombs DC" : {
     "name" : "5.6mm Flobert à plombs DC",
     "names" : [ "5.6 mm Flobert à plombs DC" ],
     "specs" : {
-      "coal_mm" : 32.1,
-      "coal_inch" : 1.26378021
+      "coal_mm" : "32.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page6.pdf" ],
-    "diameter_mm" : 5.73,
-    "diameter_inch" : 0.22559067300000002
+    "diameter_mm" : "5.73"
   },
   "5.6mm Flobert à plombs SC" : {
     "name" : "5.6mm Flobert à plombs SC",
     "names" : [ "5.6 mm Flobert à plombs SC" ],
     "specs" : {
-      "coal_mm" : 22.1,
-      "coal_inch" : 0.87007921
+      "coal_mm" : "22.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page5.pdf" ],
-    "diameter_mm" : 5.73,
-    "diameter_inch" : 0.22559067300000002
+    "diameter_mm" : "5.73"
   },
   "5mm Remington Magnum" : {
     "name" : "5mm Remington Magnum",
     "names" : [ "5 mm Rem.Mag." ],
     "specs" : {
-      "coal_mm" : 32.89,
-      "coal_inch" : 1.294882589
+      "coal_mm" : "32.89"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page3.pdf" ],
-    "diameter_mm" : 5.21,
-    "diameter_inch" : 0.205118221
+    "diameter_mm" : "5.21"
   },
   "6mm Flobert à balle" : {
     "name" : "6mm Flobert à balle",
     "names" : [ "6 mm Flobert à balle" ],
     "specs" : {
-      "coal_mm" : 12.7,
-      "coal_inch" : 0.5000002699999999
+      "coal_mm" : "12.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page7.pdf" ],
-    "diameter_mm" : 5.87,
-    "diameter_inch" : 0.231102487
+    "diameter_mm" : "5.87"
   },
   "6mm Flobert à balle DC" : {
     "name" : "6mm Flobert à balle DC",
     "names" : [ "6 mm Flobert à balle DC" ],
     "specs" : {
-      "coal_mm" : 12.7,
-      "coal_inch" : 0.5000002699999999
+      "coal_mm" : "12.7"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page8.pdf" ],
-    "diameter_mm" : 5.87,
-    "diameter_inch" : 0.231102487
+    "diameter_mm" : "5.87"
   },
   "6mm ME Flobert court" : {
     "name" : "6mm ME Flobert court",
     "names" : [ "6 mm ME Flobert court" ],
     "specs" : {
-      "coal_mm" : 9.2,
-      "coal_inch" : 0.36220491999999993
+      "coal_mm" : "9.2"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/6mm-me-flobert-court-en.pdf" ],
-    "diameter_mm" : 5.65,
-    "diameter_inch" : 0.222441065
+    "diameter_mm" : "5.65"
   },
   "9mm Flobert à balle" : {
     "name" : "9mm Flobert à balle",
     "names" : [ "9 mm Flobert à balle" ],
     "specs" : {
-      "coal_mm" : 18.1,
-      "coal_inch" : 0.71259881
+      "coal_mm" : "18.1"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page10.pdf" ],
-    "diameter_mm" : 8.8,
-    "diameter_inch" : 0.34645688
+    "diameter_mm" : "8.8"
   },
   "9mm Flobert à plombs Carton" : {
     "name" : "9mm Flobert à plombs Carton",
     "names" : [ "9 mm Flobert à plombs Carton" ],
     "specs" : {
-      "coal_mm" : 45.0,
-      "coal_inch" : 1.7716545
+      "coal_mm" : "45.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page11.pdf" ],
-    "diameter_mm" : 8.8,
-    "diameter_inch" : 0.34645688
+    "diameter_mm" : "8.8"
   },
   "9mm Flobert à plombs Metal" : {
     "name" : "9mm Flobert à plombs Metal",
     "names" : [ "9 mm Flobert à plombs Metal" ],
     "specs" : {
-      "coal_mm" : 45.0,
-      "coal_inch" : 1.7716545
+      "coal_mm" : "45.0"
     },
     "standard" : "CIP",
     "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-v/tabvcal-en-page12.pdf" ],
-    "diameter_mm" : 8.8,
-    "diameter_inch" : 0.34645688
+    "diameter_mm" : "8.8"
   }
 }

--- a/data/shotshell/cip.json
+++ b/data/shotshell/cip.json
@@ -1,56 +1,380 @@
 {
-    "4/82": {},
-    "4/101": {},
-    "8/82": {},
-    "8/100": {},
-    "10/76": {},
-    "10/82": {},
-    "10/89": {},
-    "12/35 T": {},
-    "12/50 SAPL": {},
-    "12/60": {},
-    "12/65": {},
-    "12/67": {},
-    "12/70": {},
-    "12/73": {},
-    "12/76": {},
-    "12/89": {},
-    "14/65": {},
-    "14/67": {},
-    "14/70": {},
-    "16/65": {},
-    "16/67": {},
-    "16/70": {},
-    "16/76": {},
-    "20/65": {},
-    "20/67": {},
-    "20/70": {},
-    "20/76": {},
-    "20/89": {},
-    "24/63.50": {},
-    "24/65": {},
-    "24/70": {},
-    "28/58.50": {},
-    "28/63.50": {},
-    "28/65": {},
-    "28/70": {},
-    "28/76": {},
-    "32/50.70": {},
-    "32/60": {},
-    "32/63.5": {},
-    "32/65": {},
-    "32/70": {},
-    "32/65 RUS": {},
-    "32/70 RUS": {},
-    "410/50.70": {},
-    "410/63.50": {},
-    "410/65": {},
-    "410/70": {},
-    "410/73": {},
-    "410/76": {},
-    "6 mm Centrale FALCO": {},
-    "8 mm C.F.": {},
-    "8/47.5 mm C.F.": {},
-    "9 mm C.F.": {},
-    "9 mm C.F. Mori": {}
+  "10/76" : {
+    "name" : "10/76",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page3.pdf" ]
+  },
+  "10/82" : {
+    "name" : "10/82",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page3.pdf" ]
+  },
+  "10/89" : {
+    "name" : "10/89",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page3.pdf" ]
+  },
+  "12/35 T" : {
+    "name" : "12/35 T",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "12/50 SAPL" : {
+    "name" : "12/50 SAPL",
+    "names" : [ "12/50 Short ActionPL" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "12/60" : {
+    "name" : "12/60",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "12/65" : {
+    "name" : "12/65",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "12/67" : {
+    "name" : "12/67",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "12/70" : {
+    "name" : "12/70",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "12/73" : {
+    "name" : "12/73",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "12/76" : {
+    "name" : "12/76",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "12/89" : {
+    "name" : "12/89",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+  },
+  "14/65" : {
+    "name" : "14/65",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page5.pdf" ]
+  },
+  "14/67" : {
+    "name" : "14/67",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page5.pdf" ]
+  },
+  "14/70" : {
+    "name" : "14/70",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page5.pdf" ]
+  },
+  "16/65" : {
+    "name" : "16/65",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page6.pdf" ]
+  },
+  "16/67" : {
+    "name" : "16/67",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page6.pdf" ]
+  },
+  "16/70" : {
+    "name" : "16/70",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page6.pdf" ]
+  },
+  "16/76" : {
+    "name" : "16/76",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page6.pdf" ]
+  },
+  "20/65" : {
+    "name" : "20/65",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page7.pdf" ]
+  },
+  "20/67" : {
+    "name" : "20/67",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page7.pdf" ]
+  },
+  "20/70" : {
+    "name" : "20/70",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page7.pdf" ]
+  },
+  "20/76" : {
+    "name" : "20/76",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page7.pdf" ]
+  },
+  "20/89" : {
+    "name" : "20/89",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page7.pdf" ]
+  },
+  "24/63.50" : {
+    "name" : "24/63.50",
+    "names" : [ "24/63.5" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page8.pdf" ]
+  },
+  "24/65" : {
+    "name" : "24/65",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page8.pdf" ]
+  },
+  "24/70" : {
+    "name" : "24/70",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page8.pdf" ]
+  },
+  "28/58.50" : {
+    "name" : "28/58.50",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabvii-28-170717-en.pdf" ]
+  },
+  "28/63.50" : {
+    "name" : "28/63.50",
+    "names" : [ "28/63.5" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page9.pdf" ]
+  },
+  "28/65" : {
+    "name" : "28/65",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabvii-28-170717-en.doc.pdf" ]
+  },
+  "28/70" : {
+    "name" : "28/70",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page9.pdf" ]
+  },
+  "28/76" : {
+    "name" : "28/76",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page9.pdf" ]
+  },
+  "32/50.70" : {
+    "name" : "32/50.70",
+    "names" : [ "32/50.7" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page10.pdf" ]
+  },
+  "32/60" : {
+    "name" : "32/60",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page10.pdf" ]
+  },
+  "32/63.5" : {
+    "name" : "32/63.5",
+    "names" : [ "32/63.50" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page10.pdf" ]
+  },
+  "32/65" : {
+    "name" : "32/65",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page10.pdf" ]
+  },
+  "32/65 RUS" : {
+    "name" : "32/65 RUS",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page11.pdf" ]
+  },
+  "32/70" : {
+    "name" : "32/70",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page10.pdf" ]
+  },
+  "32/70 RUS" : {
+    "name" : "32/70 RUS",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page11.pdf" ]
+  },
+  "4/101" : {
+    "name" : "4/101",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page1.pdf" ]
+  },
+  "4/82" : {
+    "name" : "4/82",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page1.pdf" ]
+  },
+  "410/50.70" : {
+    "name" : "410/50.70",
+    "names" : [ "36", "410/50.7" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/410-en-1.pdf" ]
+  },
+  "410/63.50" : {
+    "name" : "410/63.50",
+    "names" : [ "36", "410/63.5" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/410-en-2.pdf" ]
+  },
+  "410/65" : {
+    "name" : "410/65",
+    "names" : [ "36" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/410-en-3.pdf" ]
+  },
+  "410/70" : {
+    "name" : "410/70",
+    "names" : [ "36" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/410-en-4.pdf" ]
+  },
+  "410/73" : {
+    "name" : "410/73",
+    "names" : [ "36" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/410-en-5.pdf" ]
+  },
+  "410/76" : {
+    "name" : "410/76",
+    "names" : [ "36" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/410-en-6.pdf" ]
+  },
+  "6 mm Centrale FALCO" : {
+    "name" : "6 mm Centrale FALCO",
+    "names" : [ "6mm Centrale FALCO" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/6-mm-centrale-falco-en.pdf" ]
+  },
+  "8 mm C.F." : {
+    "name" : "8 mm C.F.",
+    "names" : [ "8mm C.F." ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page13.pdf" ]
+  },
+  "8/100" : {
+    "name" : "8/100",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page2.pdf" ]
+  },
+  "8/47.5 mm C.F." : {
+    "name" : "8/47.5 mm C.F.",
+    "names" : [ "8/47.5mm C.F." ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page14.pdf" ]
+  },
+  "8/82" : {
+    "name" : "8/82",
+    "names" : [ ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page2.pdf" ]
+  },
+  "9 mm C.F." : {
+    "name" : "9 mm C.F.",
+    "names" : [ "9mm C.F." ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page15.pdf" ]
+  },
+  "9 mm C.F. Mori" : {
+    "name" : "9 mm C.F. Mori",
+    "names" : [ "9mm C.F. Mori" ],
+    "specs" : { },
+    "standard" : "CIP",
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page16.pdf" ]
+  }
 }

--- a/data/shotshell/cip.json
+++ b/data/shotshell/cip.json
@@ -25,63 +25,63 @@
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/12-55-en.pdf" ]
   },
   "12/50 SAPL" : {
     "name" : "12/50 SAPL",
     "names" : [ "12/50 Short ActionPL" ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-x/12-50sapl-en.pdf" ]
   },
   "12/60" : {
     "name" : "12/60",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/12-55-en.pdf" ]
   },
   "12/65" : {
     "name" : "12/65",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/12-55-en.pdf" ]
   },
   "12/67" : {
     "name" : "12/67",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/12-55-en.pdf" ]
   },
   "12/70" : {
     "name" : "12/70",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/12-55-en.pdf" ]
   },
   "12/73" : {
     "name" : "12/73",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/12-55-en.pdf" ]
   },
   "12/76" : {
     "name" : "12/76",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/12-55-en.pdf" ]
   },
   "12/89" : {
     "name" : "12/89",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page4.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/12-55-en.pdf" ]
   },
   "14/65" : {
     "name" : "14/65",
@@ -200,28 +200,28 @@
     "names" : [ "28/63.5" ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page9.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/28-70-en.pdf" ]
   },
   "28/65" : {
     "name" : "28/65",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabvii-28-170717-en.doc.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/28-70-en.pdf" ]
   },
   "28/70" : {
     "name" : "28/70",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page9.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/28-70-en.pdf" ]
   },
   "28/76" : {
     "name" : "28/76",
     "names" : [ ],
     "specs" : { },
     "standard" : "CIP",
-    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/tabviical-en-page9.pdf" ]
+    "references" : [ "https://bobp.cip-bobp.org/uploads/tdcc/tab-vii/28-76-en.pdf" ]
   },
   "32/50.70" : {
     "name" : "32/50.70",


### PR DESCRIPTION
Here is the cartridge data for most of the CIP cartridges.
Some data is currently missing, i will add this later on.

As the data is extracted by a program the order of the cartridges has been changed.