### PR TITLE
Add an openai based parser for the saami pdf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+scraper/saami/dev.env
+scraper/saami/__pycache__

--- a/data/rifle/saami.json
+++ b/data/rifle/saami.json
@@ -1168,5 +1168,245 @@
     "standard": "SAAMI",
     "diameter_in": 0.512,
     "diameter_mm": 13.00
+  },
+  {
+    "name": "21 SHARP",
+    "specs": {
+      "coal_in": 1.0,
+      "coal_mm": 25.40
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2105,
+    "diameter_mm": 5.347
+  },
+  {
+    "name": "22 Creedmoor",
+    "specs": {
+      "coal_in": 2.70,
+      "coal_mm": 68.58
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.224,
+    "diameter_mm": 5.700
+  },
+  {
+    "name": "22 Nosler",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.40
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "224 Valkyrie",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.40
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "277 SIG FURY",
+    "specs": {
+      "coal_in": 2.825,
+      "coal_mm": 71.76
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2780,
+    "diameter_mm": 7.061
+  },
+  {
+    "name": "5.7 X 28 FN",
+    "specs": {
+      "coal_in": 1.594,
+      "coal_mm": 40.50
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.224,
+    "diameter_mm": 5.70
+  },
+  {
+    "name": "6 ARC",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2433,
+    "diameter_mm": 6.180
+  },
+  {
+    "name": "6mm Creedmoor",
+    "specs": {
+      "coal_in": 2.80,
+      "coal_mm": 71.12
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2434,
+    "diameter_mm": 6.182
+  },
+  {
+    "name": "6mm GT",
+    "specs": {
+      "coal_in": 2.64,
+      "coal_mm": 67.06
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2433,
+    "diameter_mm": 6.180
+  },
+  {
+    "name": "6.5-284 Norma",
+    "specs": {
+      "coal_in": 3.228,
+      "coal_mm": 82.00
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2642,
+    "diameter_mm": 6.710
+  },
+  {
+    "name": "6.5-300 Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.60,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2644,
+    "diameter_mm": 6.716
+  },
+  {
+    "name": "6.5 PRC",
+    "specs": {
+      "coal_in": 2.955,
+      "coal_mm": 75.06
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2644,
+    "diameter_mm": 6.716
+  },
+  {
+    "name": "6.5 Weatherby Rebated Precision Magnum",
+    "specs": {
+      "coal_in": 3.340,
+      "coal_mm": 84.836
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2643,
+    "diameter_mm": 6.713
+  },
+  {
+    "name": "6.8 True Velocity Composite",
+    "specs": {
+      "coal_in": 2.810,
+      "coal_mm": 71.37
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2777,
+    "diameter_mm": 7.054
+  },
+  {
+    "name": "6.8 Western",
+    "specs": {
+      "coal_in": 2.955,
+      "coal_mm": 75.06
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.278,
+    "diameter_mm": 7.06
+  },
+  {
+    "name": "7 PRC",
+    "specs": {
+      "coal_in": 3.340,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2844,
+    "diameter_mm": 7.224
+  },
+  {
+    "name": "300 Norma Magnum",
+    "specs": {
+      "coal_in": 3.681,
+      "coal_mm": 93.50
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.3083,
+    "diameter_mm": 7.83
+  },
+  {
+    "name": "300 PRC",
+    "specs": {
+      "coal_in": 3.700,
+      "coal_mm": 93.98
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.3084,
+    "diameter_mm": 7.833
+  },
+  {
+    "name": "300 HAM'R",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.40
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.309,
+    "diameter_mm": 7.85
+  },
+  {
+    "name": "338 Norma Magnum",
+    "specs": {
+      "coal_in": 3.681,
+      "coal_mm": 93.50
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.3386,
+    "diameter_mm": 8.60
+  },
+  {
+    "name": "338 Weatherby Rebated Precision Magnum",
+    "specs": {
+      "coal_in": 3.380,
+      "coal_mm": 85.85
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.3383,
+    "diameter_mm": 8.593
+  },
+  {
+    "name": "350 Legend",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.40
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.3570,
+    "diameter_mm": 9.068
+  },
+  {
+    "name": "360 Buckhammer",
+    "specs": {
+      "coal_in": 2.50,
+      "coal_mm": 63.50
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.359,
+    "diameter_mm": 9.12
+  },
+  {
+    "name": "400 Legend",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.40
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.4005,
+    "diameter_mm": 10.173
   }
 ]

--- a/data/rifle/saami.json
+++ b/data/rifle/saami.json
@@ -10,7 +10,7 @@
     "diameter_mm": 6.185
   },
   {
-    "name": "6mm REMINGTON",
+    "name": "6mm Remington",
     "specs": {
       "coal_in": 2.825,
       "coal_mm": 71.76
@@ -40,7 +40,7 @@
     "diameter_mm": 6.713
   },
   {
-    "name": "6.5 X 55 SWEDISH",
+    "name": "6.5 X 55 Swedish",
     "specs": {
       "coal_in": 3.150,
       "coal_mm": 80.01
@@ -50,7 +50,7 @@
     "diameter_mm": 6.71
   },
   {
-    "name": "6.8mm REMINGTON SPC",
+    "name": "6.8mm Remington SPC",
     "specs": {
       "coal_in": 2.260,
       "coal_mm": 57.40
@@ -130,7 +130,7 @@
     "diameter_mm": 7.226
   },
   {
-    "name": "7mm-08 REMINGTON",
+    "name": "7mm-08 Remington",
     "specs": {
       "coal_in": 2.800,
       "coal_mm": 71.12
@@ -140,7 +140,7 @@
     "diameter_mm": 7.226
   },
   {
-    "name": "7 x 64 BRENNEKE",
+    "name": "7 x 64 Brenneke",
     "specs": {
       "coal_in": 3.307,
       "coal_mm": 83.998
@@ -180,7 +180,7 @@
     "diameter_mm": 8.204
   },
   {
-    "name": "8mm REMINGTON MAGNUM",
+    "name": "8mm Remington Magnum",
     "specs": {
       "coal_in": 3.6,
       "coal_mm": 91.44
@@ -210,7 +210,7 @@
     "diameter_mm": 4.382
   },
   {
-    "name": "17 REMINGTON",
+    "name": "17 Remington",
     "specs": {
       "coal_in": 2.150,
       "coal_mm": 54.61
@@ -230,7 +230,7 @@
     "diameter_mm": 4.382
   },
   {
-    "name": "204 RUGER",
+    "name": "204 Ruger",
     "specs": {
       "coal_in": 2.260,
       "coal_mm": 57.4
@@ -240,7 +240,7 @@
     "diameter_mm": 5.194
   },
   {
-    "name": "218 BEE",
+    "name": "218 Bee",
     "specs": {
       "coal_in": 1.680,
       "coal_mm": 42.67
@@ -250,7 +250,7 @@
     "diameter_mm": 5.702
   },
   {
-    "name": "22 HORNET",
+    "name": "22 Hornet",
     "specs": {
       "coal_in": 1.723,
       "coal_mm": 43.76
@@ -260,7 +260,7 @@
     "diameter_mm": 5.702
   },
   {
-    "name": "22-250 REMINGTON",
+    "name": "22-250 Remington",
     "specs": {
       "coal_in": 2.35,
       "coal_mm": 59.69
@@ -280,7 +280,7 @@
     "diameter_mm": 5.702
   },
   {
-    "name": "221 REMINGTON FIREBALL",
+    "name": "221 Remington Fireball",
     "specs": {
       "coal_in": 1.83,
       "coal_mm": 46.48
@@ -290,7 +290,7 @@
     "standard": "SAAMI"
   },
   {
-    "name": "222 REMINGTON",
+    "name": "222 Remington",
     "specs": {
       "coal_in": 2.130,
       "coal_mm": 54.10
@@ -300,7 +300,7 @@
     "standard": "SAAMI"
   },
   {
-    "name": "222 REMINGTON MAGNUM",
+    "name": "222 Remington Magnum",
     "specs": {
       "coal_in": 2.280,
       "coal_mm": 57.91
@@ -310,7 +310,7 @@
     "standard": "SAAMI"
   },
   {
-    "name": "223 REMINGTON",
+    "name": "223 Remington",
     "specs": {
       "coal_in": 2.26,
       "coal_mm": 57.4
@@ -320,7 +320,7 @@
     "diameter_mm": 5.702
   },
   {
-    "name": "223 WINCHESTER SUPER SHORT MAGNUM",
+    "name": "223 Winchester Super Short Magnum",
     "specs": {
       "coal_in": 2.360,
       "coal_mm": 59.94
@@ -340,7 +340,7 @@
     "diameter_mm": 5.702
   },
   {
-    "name": "243 WINCHESTER",
+    "name": "243 Winchester",
     "specs": {
       "coal_in": 2.71,
       "coal_mm": 68.83
@@ -350,7 +350,7 @@
     "diameter_mm": 6.172
   },
   {
-    "name": "243 WINCHESTER SUPER SHORT MAGNUM",
+    "name": "243 Winchester Super Short Magnum",
     "specs": {
       "coal_in": 2.360,
       "coal_mm": 59.94
@@ -360,7 +360,7 @@
     "diameter_mm": 6.172
   },
   {
-    "name": "25-06 REMINGTON",
+    "name": "25-06 Remington",
     "specs": {
       "coal_in": 3.250,
       "coal_mm": 82.55
@@ -370,7 +370,7 @@
     "diameter_mm": 6.541
   },
   {
-    "name": "25-20 WINCHESTER",
+    "name": "25-20 Winchester",
     "specs": {
       "coal_in": 1.592,
       "coal_mm": 40.44
@@ -380,7 +380,7 @@
     "diameter_mm": 6.541
   },
   {
-    "name": "25-35 WINCHESTER",
+    "name": "25-35 Winchester",
     "specs": {
       "coal_in": 2.550,
       "coal_mm": 64.77
@@ -390,7 +390,7 @@
     "diameter_mm": 6.553
   },
   {
-    "name": "250 SAVAGE",
+    "name": "250 Savage",
     "specs": {
       "coal_in": 2.515,
       "coal_mm": 63.88
@@ -400,7 +400,7 @@
     "diameter_mm": 6.553
   },
   {
-    "name": "257 ROBERTS/257 ROBERTS +P",
+    "name": "257 Roberts/257 Roberts +P",
     "specs": {
       "coal_in": 2.780,
       "coal_mm": 70.612
@@ -420,7 +420,7 @@
     "diameter_mm": 6.535
   },
   {
-    "name": "26 NOSLER",
+    "name": "26 Nosler",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -430,7 +430,7 @@
     "diameter_mm": 6.718
   },
   {
-    "name": "260 REMINGTON",
+    "name": "260 Remington",
     "specs": {
       "coal_in": 2.8,
       "coal_mm": 71.12
@@ -440,7 +440,7 @@
     "diameter_mm": 6.718
   },
   {
-    "name": "264 WINCHESTER MAGNUM",
+    "name": "264 Winchester Magnum",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -450,7 +450,7 @@
     "diameter_mm": 6.73
   },
   {
-    "name": "27 NOSLER",
+    "name": "27 Nosler",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -470,7 +470,7 @@
     "diameter_mm": 7.043
   },
   {
-    "name": "270 WINCHESTER",
+    "name": "270 Winchester",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -480,7 +480,7 @@
     "diameter_mm": 7.061
   },
   {
-    "name": "270 WINCHESTER SHORT MAGNUM",
+    "name": "270 Winchester Short Magnum",
     "specs": {
       "coal_in": 2.860,
       "coal_mm": 72.64
@@ -490,7 +490,7 @@
     "diameter_mm": 7.061
   },
   {
-    "name": "28 NOSLER",
+    "name": "28 Nosler",
     "specs": {
       "coal_in": 3.340,
       "coal_mm": 84.84
@@ -510,7 +510,7 @@
     "diameter_mm": 7.226
   },
   {
-    "name": "280 REMINGTON",
+    "name": "280 Remington",
     "specs": {
       "coal_in": 3.330,
       "coal_mm": 84.58
@@ -520,7 +520,7 @@
     "diameter_mm": 7.226
   },
   {
-    "name": "284 WINCHESTER",
+    "name": "284 Winchester",
     "specs": {
       "coal_in": 2.800,
       "coal_mm": 71.12
@@ -540,7 +540,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "30 NOSLER",
+    "name": "30 Nosler",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -550,7 +550,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "30 REMINGTON AR",
+    "name": "30 Remington AR",
     "specs": {
       "coal_in": 2.26,
       "coal_mm": 57.4
@@ -570,7 +570,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "30-06 SPRINGFIELD",
+    "name": "30-06 Springfield",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -580,7 +580,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "30-30 WINCHESTER",
+    "name": "30-30 Winchester",
     "specs": {
       "coal_in": 2.550,
       "coal_mm": 64.77
@@ -590,7 +590,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "30-40 KRAG",
+    "name": "30-40 Krag",
     "specs": {
       "coal_in": 3.089,
       "coal_mm": 78.46
@@ -610,7 +610,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "300 HOLLAND & HOLLAND MAGNUM",
+    "name": "300 Holland & Holland Magnum",
     "specs": {
       "coal_in": 3.6,
       "coal_mm": 91.44
@@ -630,7 +630,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "300 REMINGTON ULTRA MAGNUM",
+    "name": "300 Remington Ultra Magnum",
     "specs": {
       "coal_in": 3.600,
       "coal_mm": 91.44
@@ -640,7 +640,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "300 RUGER COMPACT MAGNUM",
+    "name": "300 Ruger Compact Magnum",
     "specs": {
       "coal_in": 2.840,
       "coal_mm": 72.14
@@ -650,7 +650,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "300 SAVAGE",
+    "name": "300 Savage",
     "specs": {
       "coal_in": 2.600,
       "coal_mm": 66.04
@@ -660,7 +660,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "300 WEATHERBY MAGNUM",
+    "name": "300 Weatherby Magnum",
     "specs": {
       "coal_in": 3.560,
       "coal_mm": 90.424
@@ -670,7 +670,7 @@
     "diameter_mm": 7.83
   },
   {
-    "name": "300 WINCHESTER MAGNUM",
+    "name": "300 Winchester Magnum",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -680,7 +680,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "300 WINCHESTER SHORT MAGNUM",
+    "name": "300 Winchester Short Magnum",
     "specs": {
       "coal_in": 2.86,
       "coal_mm": 72.64
@@ -700,7 +700,7 @@
     "diameter_mm": 7.938
   },
   {
-    "name": "307 WINCHESTER",
+    "name": "307 Winchester",
     "specs": {
       "coal_in": 2.560,
       "coal_mm": 72.9
@@ -710,7 +710,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "308 MARLIN EXPRESS",
+    "name": "308 Marlin Express",
     "specs": {
       "coal_in": 2.600,
       "coal_mm": 64.04
@@ -720,7 +720,7 @@
     "diameter_mm": 7.836
   },
   {
-    "name": "308 WINCHESTER",
+    "name": "308 Winchester",
     "specs": {
       "coal_in": 2.810,
       "coal_mm": 71.374
@@ -730,7 +730,7 @@
     "diameter_mm": 7.849
   },
   {
-    "name": "32 WINCHESTER SPECIAL",
+    "name": "32 Winchester Special",
     "specs": {
       "coal_in": 2.565,
       "coal_mm": 65.15
@@ -740,7 +740,7 @@
     "diameter_mm": 8.179
   },
   {
-    "name": "32-20 WINCHESTER",
+    "name": "32-20 Winchester",
     "specs": {
       "coal_in": 1.592,
       "coal_mm": 40.44
@@ -750,7 +750,7 @@
     "diameter_mm": 7.938
   },
   {
-    "name": "325 WINCHESTER SHORT MAGNUM",
+    "name": "325 Winchester Short Magnum",
     "specs": {
       "coal_in": 2.86,
       "coal_mm": 72.64
@@ -760,7 +760,7 @@
     "diameter_mm": 8.217
   },
   {
-    "name": "33 NOSLER",
+    "name": "33 Nosler",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -770,7 +770,7 @@
     "diameter_mm": 8.611
   },
   {
-    "name": "338 FEDERAL",
+    "name": "338 Federal",
     "specs": {
       "coal_in": 2.820,
       "coal_mm": 71.63
@@ -800,7 +800,7 @@
     "diameter_mm": 8.598
   },
   {
-    "name": "338 REMINGTON ULTRA MAGNUM",
+    "name": "338 Remington Ultra Magnum",
     "specs": {
       "coal_in": 3.600,
       "coal_mm": 91.44
@@ -810,7 +810,7 @@
     "diameter_mm": 8.593
   },
   {
-    "name": "338 RUGER COMPACT MAGNUM",
+    "name": "338 Ruger Compact Magnum",
     "specs": {
       "coal_in": 2.840,
       "coal_mm": 72.14
@@ -820,7 +820,7 @@
     "diameter_mm": 8.61
   },
   {
-    "name": "338 WINCHESTER MAGNUM",
+    "name": "338 Winchester Magnum",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -840,7 +840,7 @@
     "diameter_mm": 8.593
   },
   {
-    "name": "348 WINCHESTER",
+    "name": "348 Winchester",
     "specs": {
       "coal_in": 2.795,
       "coal_mm": 70.99
@@ -850,7 +850,7 @@
     "diameter_mm": 8.877
   },
   {
-    "name": "35 NOSLER",
+    "name": "35 Nosler",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -860,7 +860,7 @@
     "diameter_mm": 9.119
   },
   {
-    "name": "35 REMINGTON",
+    "name": "35 Remington",
     "specs": {
       "coal_in": 2.525,
       "coal_mm": 64.14
@@ -890,7 +890,7 @@
     "diameter_mm": 9.119
   },
   {
-    "name": "356 WINCHESTER",
+    "name": "356 Winchester",
     "specs": {
       "coal_in": 2.560,
       "coal_mm": 65.02
@@ -900,7 +900,7 @@
     "diameter_mm": 9.106
   },
   {
-    "name": "358 WINCHESTER",
+    "name": "358 Winchester",
     "specs": {
       "coal_in": 2.780,
       "coal_mm": 70.61
@@ -910,7 +910,7 @@
     "diameter_mm": 9.106
   },
   {
-    "name": "36 NOSLER",
+    "name": "36 Nosler",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -930,7 +930,7 @@
     "diameter_mm": 9.3
   },
   {
-    "name": "375 HOLLAND & HOLLAND MAGNUM",
+    "name": "375 Holland & Holland Magnum",
     "specs": {
       "coal_in": 3.60,
       "coal_mm": 91.44
@@ -940,7 +940,7 @@
     "diameter_mm": 9.55
   },
   {
-    "name": "375 REMINGTON ULTRA MAGNUM",
+    "name": "375 Remington Ultra Magnum",
     "specs": {
       "coal_in": 3.6,
       "coal_mm": 91.44
@@ -950,7 +950,7 @@
     "diameter_mm": 9.55
   },
   {
-    "name": "375 RUGER",
+    "name": "375 Ruger",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -960,7 +960,7 @@
     "diameter_mm": 9.55
   },
   {
-    "name": "375 WINCHESTER",
+    "name": "375 Winchester",
     "specs": {
       "coal_in": 2.56,
       "coal_mm": 65.02
@@ -970,7 +970,7 @@
     "diameter_mm": 9.55
   },
   {
-    "name": "376 STEYR",
+    "name": "376 Steyr",
     "specs": {
       "coal_in": 3.11,
       "coal_mm": 79.00
@@ -980,7 +980,7 @@
     "diameter_mm": 9.55
   },
   {
-    "name": "38-40 WINCHESTER",
+    "name": "38-40 Winchester",
     "specs": {
       "coal_in": 1.592,
       "coal_mm": 40.44
@@ -990,7 +990,7 @@
     "diameter_mm": 10.173
   },
   {
-    "name": "38-55 WINCHESTER",
+    "name": "38-55 Winchester",
     "specs": {
       "coal_in": 2.510,
       "coal_mm": 63.75
@@ -1000,7 +1000,7 @@
     "diameter_mm": 9.576
   },
   {
-    "name": "405 WINCHESTER",
+    "name": "405 Winchester",
     "specs": {
       "coal_in": 3.115,
       "coal_mm": 79.12
@@ -1010,7 +1010,7 @@
     "diameter_mm": 10.452
   },
   {
-    "name": "416 REMINGTON MAGNUM",
+    "name": "416 Remington Magnum",
     "specs": {
       "coal_in": 3.600,
       "coal_mm": 91.44
@@ -1020,7 +1020,7 @@
     "diameter_mm": 10.566
   },
   {
-    "name": "416 RIGBY",
+    "name": "416 Rigby",
     "specs": {
       "coal_in": 3.750,
       "coal_mm": 95.250
@@ -1030,7 +1030,7 @@
     "diameter_mm": 10.579
   },
   {
-    "name": "416 RUGER",
+    "name": "416 Ruger",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -1050,7 +1050,7 @@
     "diameter_mm": 10.57
   },
   {
-    "name": "44 REMINGTON MAGNUM",
+    "name": "44 Remington Magnum",
     "specs": {
       "coal_in": 1.61,
       "coal_mm": 40.89
@@ -1060,7 +1060,7 @@
     "diameter_mm": 10.973
   },
   {
-    "name": "44-40 WINCHESTER",
+    "name": "44-40 Winchester",
     "specs": {
       "coal_in": 1.592,
       "coal_mm": 40.44
@@ -1070,7 +1070,7 @@
     "diameter_mm": 10.846
   },
   {
-    "name": "444 MARLIN",
+    "name": "444 Marlin",
     "specs": {
       "coal_in": 2.570,
       "coal_mm": 65.28
@@ -1080,7 +1080,7 @@
     "diameter_mm": 10.935
   },
   {
-    "name": "45-70 GOVERNMENT",
+    "name": "45-70 Government",
     "specs": {
       "coal_in": 2.550,
       "coal_mm": 64.77
@@ -1090,7 +1090,7 @@
     "diameter_mm": 11.633
   },
   {
-    "name": "450 BUSHMASTER",
+    "name": "450 Bushmaster",
     "specs": {
       "coal_in": 2.26,
       "coal_mm": 57.4
@@ -1100,7 +1100,7 @@
     "diameter_mm": 11.494
   },
   {
-    "name": "450 MARLIN",
+    "name": "450 Marlin",
     "specs": {
       "coal_in": 2.550,
       "coal_mm": 64.76
@@ -1110,7 +1110,7 @@
     "diameter_mm": 11.641
   },
   {
-    "name": "457 WILD WEST GUNS",
+    "name": "457 Wild west guns",
     "specs": {
       "coal_in": 2.565,
       "coal_mm": 67.69
@@ -1130,7 +1130,7 @@
     "diameter_mm": 11.66
   },
   {
-    "name": "458 WINCHESTER MAGNUM",
+    "name": "458 Winchester Magnum",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
@@ -1140,7 +1140,7 @@
     "diameter_mm": 11.659
   },
   {
-    "name": "470 NITRO EXPRESS",
+    "name": "470 Nitro Express",
     "specs": {
       "coal_in": 3.980,
       "coal_mm": 101.092
@@ -1150,7 +1150,7 @@
     "diameter_mm": 12.05
   },
   {
-    "name": "475 TURNBULL",
+    "name": "475 Turnbull",
     "specs": {
       "coal_in": 2.780,
       "coal_mm": 70.61
@@ -1160,7 +1160,7 @@
     "diameter_mm": 12.078
   },
   {
-    "name": "500 NITRO EXPRESS 3",
+    "name": "500 Nitro Express 3",
     "specs": {
       "coal_in": 3.75,
       "coal_mm": 95.25

--- a/data/rifle/saami.json
+++ b/data/rifle/saami.json
@@ -1,240 +1,1109 @@
-{
-  "17 Hornet": {
-  },
-  "17 Remington Fireball": {
-  },
-  "17 Remington": {
-  },
-  "204 Ruger": {
-  },
-  "218 Bee": {
-  },
-  "22 Hornet": {
-  },
-  "22-250 Remington": {
-  },
-  "220 Swift": {
-  },
-  "221 Remington Fireball": {
-  },
-  "222 Remington Magnum": {
-  },
-  "222 Remington": {
-  },
-  "223 Remington": {
-  },
-  "223 Winchester Super Short Magnum": {
-  },
-  "225 Winchester": {
-  },
-  "243 Winchester Super Short Magnum": {
-  },
-  "243 Winchester": {
-  },
-  "25 Winchester Super Short Magnum": {
-  },
-  "25-06 Remington": {
-  },
-  "25-20 Winchester": {
-  },
-  "25-35 Winchester": {
-  },
-  "250 Savage": {
-  },
-  "257 Roberts +P": {
-  },
-  "257 Roberts": {
-  },
-  "257 Weatherby Magnum": {
-  },
-  "26 Nosler": {
-  },
-  "260 Remington": {
-  },
-  "264 Winchester Magnum": {
-  },
-  "27 Nosler": {
-  },
-  "270 Weatherby Magnum": {
-  },
-  "270 Winchester Short Magnum": {
-  },
-  "270 Winchester": {
-  },
-  "28 Nosler": {
-  },
-  "280 Ackley Improved": {
-  },
-  "280 Remington": {
-  },
-  "284 Winchester": {
-  },
-  "30 Carbine": {
-  },
-  "30 Nosler": {
-  },
-  "30 Remington AR": {
-  },
-  "30 Thompson Center": {
-  },
-  "30-06 Springfield": {
-  },
-  "30-30 Winchester": {
-  },
-  "30-40 Krag": {
-  },
-  "300 AAC Blackout": {
-  },
-  "300 Holland & Holland Magnum": {
-  },
-  "300 Remington Short Action Ultra Magnum": {
-  },
-  "300 Remington Ultra Magnum": {
-  },
-  "300 Ruger Compact Magnum": {
-  },
-  "300 Savage": {
-  },
-  "300 Weatherby Magnum": {
-  },
-  "300 Winchester Magnum": {
-  },
-  "300 Winchester Short Magnum": {
-  },
-  "303 British": {
-  },
-  "307 Winchester": {
-  },
-  "308 Marlin Express": {
-  },
-  "308 Winchester": {
-  },
-  "32 Winchester Special": {
-  },
-  "32-20 Winchester": {
-  },
-  "325 Winchester Short Magnum": {
-  },
-  "33 Nosler": {
-  },
-  "338 Federal": {
-  },
-  "338 Lapua Magnum": {
-  },
-  "338 Marlin Express": {
-  },
-  "338 Remington Ultra Magnum": {
-  },
-  "338 Ruger Compact Magnum": {
-  },
-  "338 Winchester Magnum": {
-  },
-  "340 Weatherby Magnum": {
-  },
-  "348 Winchester": {
-  },
-  "35 Nosler": {
-  },
-  "35 Remington": {
-  },
-  "35 Whelen": {
-  },
-  "350 Remington Magnum": {
-  },
-  "356 Winchester": {
-  },
-  "358 Winchester": {
-  },
-  "36 Nosler": {
-  },
-  "370 Sako Magnum": {
-  },
-  "375 Holland & Holland Magnum": {
-  },
-  "375 Remington Ultra Magnum": {
-  },
-  "375 Ruger": {
-  },
-  "375 Winchester": {
-  },
-  "376 Steyr": {
-  },
-  "38-40 Winchester": {
-  },
-  "38-55 Winchester": {
-  },
-  "405 Winchester": {
-  },
-  "416 Remington Magnum": {
-  },
-  "416 Rigby": {
-  },
-  "416 Ruger": {
-  },
-  "416 Weatherby Magnum": {
-  },
-  "44 Remington Magnum": {
-  },
-  "44-40 Winchester": {
-  },
-  "444 Marlin": {
-  },
-  "45-70 Government": {
-  },
-  "450 Bushmaster": {
-  },
-  "450 Marlin": {
-  },
-  "457 Wild West Guns": {
-  },
-  "458 Lott": {
-  },
-  "458 Winchester Magnum": {
-  },
-  "470 Nitro Express": {
-  },
-  "475 Turnbull": {
-  },
-  "500 Nitro Express 3\"": {
-  },
-  "6 x 45mm": {
-  },
-  "6.5 Creedmoor": {
-  },
-  "6.5 Grendel": {
-  },
-  "6.5 x 55 Swedish": {
-  },
-  "6.8mm Remington SPC": {
-  },
-  "6mm Remington": {
-  },
-  "7 x 64 Brenneke": {
-  },
-  "7-30 Waters": {
-  },
-  "7.62 x 39": {
-  },
-  "7mm Mauser (7x57)": {
-  },
-  "7mm Remington Magnum": {
-  },
-  "7mm Remington Short Action Ultra Magnum": {
-  },
-  "7mm Remington Ultra Magnum": {
-  },
-  "7mm Shooting Times Westerner": {
-  },
-  "7mm Weatherby Magnum": {
-  },
-  "7mm Winchester Short Magnum": {
-  },
-  "7mm-08 Remington": {
-  },
-  "8mm Mauser (8 x 57)": {
-  },
-  "8mm Remington Magnum": {
-  },
-  "9.3 x 62": {
+[
+  {
+    "name": "280 REMINGTON",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "284 WINCHESTER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "30 Carbine",
+    "specs": {
+      "coal_in": 1.7,
+      "coal_mm": 43.18
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "30 NOSLER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "30 REMINGTON AR",
+    "specs": {
+      "coal_in": 2.26,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "30 Thompson Center",
+    "specs": {
+      "coal_in": 2.225,
+      "coal_mm": 56.51
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "30-06 SPRINGFIELD",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "30-30 WINCHESTER",
+    "specs": {
+      "coal_in": 2.557,
+      "coal_mm": 64.95
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "30-40 KRAG",
+    "specs": {
+      "coal_in": 2.93,
+      "coal_mm": 74.42
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "300 AAC Blackout",
+    "specs": {
+      "coal_in": 2.26,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "300 HOLLAND & HOLLAND MAGNUM",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "300 Remington Short Action Ultra Magnum",
+    "specs": {
+      "coal_in": 2.86,
+      "coal_mm": 72.64
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "300 REMINGTON ULTRA MAGNUM",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "300 RUGER COMPACT MAGNUM",
+    "specs": {
+      "coal_in": 2.825,
+      "coal_mm": 71.75
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "300 SAVAGE",
+    "specs": {
+      "coal_in": 2.63,
+      "coal_mm": 66.8
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "300 WEATHERBY MAGNUM",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "300 WINCHESTER MAGNUM",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "300 WINCHESTER SHORT MAGNUM",
+    "specs": {
+      "coal_in": 2.86,
+      "coal_mm": 72.646
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.823
+  },
+  {
+    "name": "303 British",
+    "specs": {
+      "coal_in": 2.89,
+      "coal_mm": 73.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.311,
+    "diameter_mm": 7.9
+  },
+  {
+    "name": "307 WINCHESTER",
+    "specs": {
+      "coal_in": 2.87,
+      "coal_mm": 72.9
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "308 MARLIN EXPRESS",
+    "specs": {
+      "coal_in": 2.55,
+      "coal_mm": 64.77
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "308 WINCHESTER",
+    "specs": {
+      "coal_in": 2.81,
+      "coal_mm": 71.37
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.308,
+    "diameter_mm": 7.82
+  },
+  {
+    "name": "32 WINCHESTER SPECIAL",
+    "specs": {
+      "coal_in": 2.56,
+      "coal_mm": 65.02
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.321,
+    "diameter_mm": 8.15
+  },
+  {
+    "name": "32-20 WINCHESTER",
+    "specs": {
+      "coal_in": 1.428,
+      "coal_mm": 36.32
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.317,
+    "diameter_mm": 8.05
+  },
+  {
+    "name": "325 WINCHESTER SHORT MAGNUM",
+    "specs": {
+      "coal_in": 2.86,
+      "coal_mm": 72.64
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.323,
+    "diameter_mm": 8.2
+  },
+  {
+    "name": "33 NOSLER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.338,
+    "diameter_mm": 8.59
+  },
+  {
+    "name": "338 FEDERAL",
+    "specs": {
+      "coal_in": 2.0,
+      "coal_mm": 50.8
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.338,
+    "diameter_mm": 8.58
+  },
+  {
+    "name": "338 Lapua Magnum",
+    "specs": {
+      "coal_in": 3.6811,
+      "coal_mm": 93.5
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.338,
+    "diameter_mm": 8.58
+  },
+  {
+    "name": "338 Marlin Express",
+    "specs": {
+      "coal_in": 3.25,
+      "coal_mm": 82.55
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.338,
+    "diameter_mm": 8.59
+  },
+  {
+    "name": "338 REMINGTON ULTRA MAGNUM",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "338 RUGER COMPACT MAGNUM",
+    "specs": {
+      "coal_in": 2.8,
+      "coal_mm": 71.12
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.338,
+    "diameter_mm": 8.59
+  },
+  {
+    "name": "338 WINCHESTER MAGNUM",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.338,
+    "diameter_mm": 8.58
+  },
+  {
+    "name": "340 Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.338,
+    "diameter_mm": 8.59
+  },
+  {
+    "name": "348 WINCHESTER",
+    "specs": {
+      "coal_in": 2.8,
+      "coal_mm": 71.12
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.348,
+    "diameter_mm": 8.84
+  },
+  {
+    "name": "35 NOSLER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.359,
+    "diameter_mm": 9.119
+  },
+  {
+    "name": "35 REMINGTON",
+    "specs": {
+      "coal_in": 2.27,
+      "coal_mm": 57.66
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.358,
+    "diameter_mm": 9.09
+  },
+  {
+    "name": "35 Whelen",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.358,
+    "diameter_mm": 9.09
+  },
+  {
+    "name": "350 Remington Magnum",
+    "specs": {
+      "coal_in": 2.825,
+      "coal_mm": 71.76
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.348,
+    "diameter_mm": 8.84
+  },
+  {
+    "name": "356 WINCHESTER",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "358 WINCHESTER",
+    "specs": {
+      "coal_in": 2.771,
+      "coal_mm": 70.41
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.358,
+    "diameter_mm": 9.09
+  },
+  {
+    "name": "36 NOSLER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.366,
+    "diameter_mm": 9.296
+  },
+  {
+    "name": "370 Sako Magnum",
+    "specs": {
+      "coal_in": 2.244,
+      "coal_mm": 57.01
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.366,
+    "diameter_mm": 9.3
+  },
+  {
+    "name": "375 HOLLAND & HOLLAND MAGNUM",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "375 REMINGTON ULTRA MAGNUM",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.375,
+    "diameter_mm": 9.525
+  },
+  {
+    "name": "375 RUGER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.375,
+    "diameter_mm": 9.53
+  },
+  {
+    "name": "375 WINCHESTER",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.375,
+    "diameter_mm": 9.53
+  },
+  {
+    "name": "376 STEYR",
+    "specs": {
+      "coal_in": 3.25,
+      "coal_mm": 82.55
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.376,
+    "diameter_mm": 9.55
+  },
+  {
+    "name": "38-40 WINCHESTER",
+    "specs": {
+      "coal_in": 1.594,
+      "coal_mm": 40.5
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.401,
+    "diameter_mm": 10.19
+  },
+  {
+    "name": "38-55 WINCHESTER",
+    "specs": {
+      "coal_in": 2.08,
+      "coal_mm": 52.83
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.376,
+    "diameter_mm": 9.55
+  },
+  {
+    "name": "405 WINCHESTER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.411,
+    "diameter_mm": 10.44
+  },
+  {
+    "name": "416 REMINGTON MAGNUM",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "416 RIGBY",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.416,
+    "diameter_mm": 10.57
+  },
+  {
+    "name": "416 RUGER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.416,
+    "diameter_mm": 10.57
+  },
+  {
+    "name": "416 Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.416,
+    "diameter_mm": 10.57
+  },
+  {
+    "name": "44 REMINGTON MAGNUM",
+    "specs": {
+      "coal_in": 1.61,
+      "coal_mm": 40.89
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.429,
+    "diameter_mm": 10.9
+  },
+  {
+    "name": "44-40 WINCHESTER",
+    "specs": {},
+    "standard": "SAAMI",
+    "diameter_in": 0.427,
+    "diameter_mm": 10.84
+  },
+  {
+    "name": "444 MARLIN",
+    "specs": {
+      "coal_in": 2.555,
+      "coal_mm": 64.77
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.429,
+    "diameter_mm": 10.9
+  },
+  {
+    "name": "45-70 GOVERNMENT",
+    "specs": {
+      "coal_in": 2.54,
+      "coal_mm": 64.52
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.458,
+    "diameter_mm": 11.63
+  },
+  {
+    "name": "450 BUSHMASTER",
+    "specs": {
+      "coal_in": 2.26,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.452,
+    "diameter_mm": 11.48
+  },
+  {
+    "name": "450 MARLIN",
+    "specs": {
+      "coal_in": 2.555,
+      "coal_mm": 64.77
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.458,
+    "diameter_mm": 11.63
+  },
+  {
+    "name": "457 WILD WEST GUNS",
+    "specs": {},
+    "standard": "SAAMI",
+    "diameter_in": 0.457,
+    "diameter_mm": 11.6
+  },
+  {
+    "name": "458 Lott",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.458,
+    "diameter_mm": 11.63
+  },
+  {
+    "name": "458 WINCHESTER MAGNUM",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.458,
+    "diameter_mm": 11.63
+  },
+  {
+    "name": "470 NITRO EXPRESS",
+    "specs": {
+      "coal_in": 3.875,
+      "coal_mm": 98.43
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.475,
+    "diameter_mm": 12.07
+  },
+  {
+    "name": "475 TURNBULL",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "500 NITRO EXPRESS 3",
+    "specs": {
+      "coal_in": 3.0,
+      "coal_mm": 76.2
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.51,
+    "diameter_mm": 12.95
+  },
+  {
+    "name": "6 X 45mm",
+    "specs": {},
+    "standard": "SAAMI",
+    "diameter_in": 0.236,
+    "diameter_mm": 6
+  },
+  {
+    "name": "6mm REMINGTON",
+    "specs": {
+      "coal_in": 2.8,
+      "coal_mm": 71.12
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.243,
+    "diameter_mm": 6.17
+  },
+  {
+    "name": "6.5 Creedmoor",
+    "specs": {
+      "coal_in": 2.825,
+      "coal_mm": 71.75
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.264,
+    "diameter_mm": 6.71
+  },
+  {
+    "name": "6.5 Grendel",
+    "specs": {
+      "coal_in": 2.26,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.264,
+    "diameter_mm": 6.71
+  },
+  {
+    "name": "6.5 X 55 SWEDISH",
+    "specs": {
+      "coal_in": 3.15,
+      "coal_mm": 80.01
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.264,
+    "diameter_mm": 6.71
+  },
+  {
+    "name": "6.8mm REMINGTON SPC",
+    "specs": {},
+    "standard": "SAAMI",
+    "diameter_in": 0.277,
+    "diameter_mm": 7.04
+  },
+  {
+    "name": "7mm Mauser (7x57)",
+    "specs": {
+      "coal_in": 3.102,
+      "coal_mm": 78.747
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.214
+  },
+  {
+    "name": "7mm Remington Magnum",
+    "specs": {
+      "coal_in": 2.76,
+      "coal_mm": 70.104
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.2136
+  },
+  {
+    "name": "7mm Remington Short Action Ultra Magnum",
+    "specs": {},
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "7mm Remington Ultra Magnum",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "7mm Shooting Times Westerner",
+    "specs": {
+      "coal_in": 3.315,
+      "coal_mm": 84.15
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "7mm Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "7mm Winchester Short Magnum",
+    "specs": {
+      "coal_in": 2.1,
+      "coal_mm": 53.34
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "7mm-08 REMINGTON",
+    "specs": {
+      "coal_in": 2.81,
+      "coal_mm": 71.37
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "7 x 64 BRENNEKE",
+    "specs": {
+      "coal_in": 3.228,
+      "coal_mm": 82.0
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "7-30 Waters",
+    "specs": {
+      "coal_in": 2.55,
+      "coal_mm": 64.77
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
+  },
+  {
+    "name": "7.62 x 39",
+    "specs": {
+      "coal_in": 2.204,
+      "coal_mm": 56.0
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.312,
+    "diameter_mm": 7.92
+  },
+  {
+    "name": "8mm Mauser (8x57)",
+    "specs": {
+      "coal_in": 3.075,
+      "coal_mm": 78.11
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.323,
+    "diameter_mm": 8.2
+  },
+  {
+    "name": "8mm REMINGTON MAGNUM",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.323,
+    "diameter_mm": 8.2
+  },
+  {
+    "name": "9.3 X 62",
+    "specs": {
+      "coal_in": 3.15,
+      "coal_mm": 80.0
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.366,
+    "diameter_mm": 9.3
+  },
+  {
+    "name": "17 Hornet",
+    "specs": {
+      "coal_in": 1.35,
+      "coal_mm": 34.29
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.172,
+    "diameter_mm": 4.37
+  },
+  {
+    "name": "17 REMINGTON",
+    "specs": {
+      "coal_in": 1.625,
+      "coal_mm": 41.275
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.172,
+    "diameter_mm": 4.368
+  },
+  {
+    "name": "17 Remington Fireball",
+    "specs": {
+      "coal_in": 1.825,
+      "coal_mm": 46.355
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.172,
+    "diameter_mm": 4.368
+  },
+  {
+    "name": "204 RUGER",
+    "specs": {
+      "coal_in": 2.26,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.204,
+    "diameter_mm": 5.18
+  },
+  {
+    "name": "218 BEE",
+    "specs": {
+      "coal_in": 1.6,
+      "coal_mm": 40.64
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.224,
+    "diameter_mm": 5.69
+  },
+  {
+    "name": "22 HORNET",
+    "specs": {
+      "coal_in": 1.713,
+      "coal_mm": 43.458
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.224,
+    "diameter_mm": 5.689
+  },
+  {
+    "name": "22-250 REMINGTON",
+    "specs": {
+      "coal_in": 2.35,
+      "coal_mm": 59.69
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.224,
+    "diameter_mm": 5.69
+  },
+  {
+    "name": "220 Swift",
+    "specs": {
+      "coal_in": 3.56,
+      "coal_mm": 90.42
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.224,
+    "diameter_mm": 5.69
+  },
+  {
+    "name": "221 REMINGTON FIREBALL",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "222 REMINGTON",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "222 REMINGTON MAGNUM",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "223 REMINGTON",
+    "specs": {
+      "coal_in": 2.26,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.224,
+    "diameter_mm": 5.69
+  },
+  {
+    "name": "223 WINCHESTER SUPER SHORT MAGNUM",
+    "specs": {},
+    "standard": "SAAMI",
+    "diameter_in": 0.223,
+    "diameter_mm": 5.66
+  },
+  {
+    "name": "225 Winchester",
+    "specs": {
+      "coal_in": 2.81,
+      "coal_mm": 71.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.224,
+    "diameter_mm": 5.56
+  },
+  {
+    "name": "243 WINCHESTER",
+    "specs": {
+      "coal_in": 2.71,
+      "coal_mm": 68.83
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.243,
+    "diameter_mm": 6.17
+  },
+  {
+    "name": "243 WINCHESTER SUPER SHORT MAGNUM",
+    "specs": {
+      "coal_in": 2.235,
+      "coal_mm": 56.77
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.243,
+    "diameter_mm": 6.17
+  },
+  {
+    "name": "25 WINCHESTER SUPER SHORT MAGNUM",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "25-06 REMINGTON",
+    "specs": {},
+    "standard": "SAAMI"
+  },
+  {
+    "name": "25-20 WINCHESTER",
+    "specs": {
+      "coal_in": 1.35,
+      "coal_mm": 34.29
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.257,
+    "diameter_mm": 6.53
+  },
+  {
+    "name": "25-35 WINCHESTER",
+    "specs": {
+      "coal_in": 2.05,
+      "coal_mm": 52.07
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.257,
+    "diameter_mm": 6.53
+  },
+  {
+    "name": "250 SAVAGE",
+    "specs": {
+      "coal_in": 2.565,
+      "coal_mm": 65.15
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.257,
+    "diameter_mm": 6.53
+  },
+  {
+    "name": "257 ROBERTS/257 ROBERTS +P",
+    "specs": {
+      "coal_in": 2.131,
+      "coal_mm": 54.13
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.257,
+    "diameter_mm": 6.53
+  },
+  {
+    "name": "257 Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.25,
+      "coal_mm": 82.55
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.257,
+    "diameter_mm": 6.528
+  },
+  {
+    "name": "26 NOSLER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.836
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.264,
+    "diameter_mm": 6.71
+  },
+  {
+    "name": "260 REMINGTON",
+    "specs": {
+      "coal_in": 2.8,
+      "coal_mm": 71.12
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.264,
+    "diameter_mm": 6.71
+  },
+  {
+    "name": "264 WINCHESTER MAGNUM",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.264,
+    "diameter_mm": 6.71
+  },
+  {
+    "name": "27 NOSLER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.277,
+    "diameter_mm": 7.04
+  },
+  {
+    "name": "270 Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.669,
+      "coal_mm": 93.22
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.277,
+    "diameter_mm": 7.04
+  },
+  {
+    "name": "270 WINCHESTER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.277,
+    "diameter_mm": 7.04
+  },
+  {
+    "name": "270 WINCHESTER SHORT MAGNUM",
+    "specs": {
+      "coal_in": 2.36,
+      "coal_mm": 59.94
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.277,
+    "diameter_mm": 7.04
+  },
+  {
+    "name": "28 NOSLER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "280 Ackley Improved",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.284,
+    "diameter_mm": 7.21
   }
-}
+]

--- a/data/rifle/saami.json
+++ b/data/rifle/saami.json
@@ -1,33 +1,543 @@
 [
   {
-    "name": "280 REMINGTON",
+    "name": "6 X 45mm",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.40
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2435,
+    "diameter_mm": 6.185
+  },
+  {
+    "name": "6mm REMINGTON",
+    "specs": {
+      "coal_in": 2.825,
+      "coal_mm": 71.76
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2435,
+    "diameter_mm": 6.185
+  },
+  {
+    "name": "6.5 Creedmoor",
+    "specs": {
+      "coal_in": 2.825,
+      "coal_mm": 71.76
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2644,
+    "diameter_mm": 6.716
+  },
+  {
+    "name": "6.5 Grendel",
+    "specs": {
+      "coal_in": 2.26,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2643,
+    "diameter_mm": 6.713
+  },
+  {
+    "name": "6.5 X 55 SWEDISH",
+    "specs": {
+      "coal_in": 3.150,
+      "coal_mm": 80.01
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2642,
+    "diameter_mm": 6.71
+  },
+  {
+    "name": "6.8mm REMINGTON SPC",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.40
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2780,
+    "diameter_mm": 7.061
+  },
+  {
+    "name": "7mm Mauser (7x57)",
+    "specs": {
+      "coal_in": 3.065,
+      "coal_mm": 77.85
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7mm Remington Magnum",
+    "specs": {
+      "coal_in": 3.290,
+      "coal_mm": 83.57
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7mm Remington Short Action Ultra Magnum",
+    "specs": {
+      "coal_in": 2.825,
+      "coal_mm": 71.76
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7mm Remington Ultra Magnum",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7mm Shooting Times Westerner",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7mm Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.360,
+      "coal_mm": 85.344
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7mm Winchester Short Magnum",
+    "specs": {
+      "coal_in": 2.860,
+      "coal_mm": 72.64
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7mm-08 REMINGTON",
+    "specs": {
+      "coal_in": 2.800,
+      "coal_mm": 71.12
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7 x 64 BRENNEKE",
+    "specs": {
+      "coal_in": 3.307,
+      "coal_mm": 83.998
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.249
+  },
+  {
+    "name": "7-30 Waters",
+    "specs": {
+      "coal_in": 2.55,
+      "coal_mm": 64.77
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "7.62 x 39",
+    "specs": {
+      "coal_in": 2.200,
+      "coal_mm": 55.88
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.311,
+    "diameter_mm": 7.90
+  },
+  {
+    "name": "8mm Mauser (8x57)",
+    "specs": {
+      "coal_in": 3.250,
+      "coal_mm": 82.55
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.323,
+    "diameter_mm": 8.204
+  },
+  {
+    "name": "8mm REMINGTON MAGNUM",
+    "specs": {
+      "coal_in": 3.6,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.3235,
+    "diameter_mm": 8.217
+  },
+  {
+    "name": "9.3 X 62",
+    "specs": {
+      "coal_in": 3.291,
+      "coal_mm": 83.6
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.366,
+    "diameter_mm": 9.3
+  },
+  {
+    "name": "17 Hornet",
+    "specs": {
+      "coal_in": 1.720,
+      "coal_mm": 43.69
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.1725,
+    "diameter_mm": 4.382
+  },
+  {
+    "name": "17 REMINGTON",
+    "specs": {
+      "coal_in": 2.150,
+      "coal_mm": 54.61
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.1725,
+    "diameter_mm": 4.382
+  },
+  {
+    "name": "17 Remington Fireball",
+    "specs": {
+      "coal_in": 1.830,
+      "coal_mm": 46.48
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.1725,
+    "diameter_mm": 4.382
+  },
+  {
+    "name": "204 RUGER",
+    "specs": {
+      "coal_in": 2.260,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2045,
+    "diameter_mm": 5.194
+  },
+  {
+    "name": "218 BEE",
+    "specs": {
+      "coal_in": 1.680,
+      "coal_mm": 42.67
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "22 HORNET",
+    "specs": {
+      "coal_in": 1.723,
+      "coal_mm": 43.76
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "22-250 REMINGTON",
+    "specs": {
+      "coal_in": 2.35,
+      "coal_mm": 59.69
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "220 Swift",
+    "specs": {
+      "coal_in": 2.680,
+      "coal_mm": 68.07
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "221 REMINGTON FIREBALL",
+    "specs": {
+      "coal_in": 1.83,
+      "coal_mm": 46.48
+    },
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702,
+    "standard": "SAAMI"
+  },
+  {
+    "name": "222 REMINGTON",
+    "specs": {
+      "coal_in": 2.130,
+      "coal_mm": 54.10
+    },
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702,
+    "standard": "SAAMI"
+  },
+  {
+    "name": "222 REMINGTON MAGNUM",
+    "specs": {
+      "coal_in": 2.280,
+      "coal_mm": 57.91
+    },
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702,
+    "standard": "SAAMI"
+  },
+  {
+    "name": "223 REMINGTON",
+    "specs": {
+      "coal_in": 2.26,
+      "coal_mm": 57.4
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "223 WINCHESTER SUPER SHORT MAGNUM",
+    "specs": {
+      "coal_in": 2.360,
+      "coal_mm": 59.94
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "225 Winchester",
+    "specs": {
+      "coal_in": 2.5,
+      "coal_mm": 63.50
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2245,
+    "diameter_mm": 5.702
+  },
+  {
+    "name": "243 WINCHESTER",
+    "specs": {
+      "coal_in": 2.71,
+      "coal_mm": 68.83
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.243,
+    "diameter_mm": 6.172
+  },
+  {
+    "name": "243 WINCHESTER SUPER SHORT MAGNUM",
+    "specs": {
+      "coal_in": 2.360,
+      "coal_mm": 59.94
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.243,
+    "diameter_mm": 6.172
+  },
+  {
+    "name": "25-06 REMINGTON",
+    "specs": {
+      "coal_in": 3.250,
+      "coal_mm": 82.55
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2575,
+    "diameter_mm": 6.541
+  },
+  {
+    "name": "25-20 WINCHESTER",
+    "specs": {
+      "coal_in": 1.592,
+      "coal_mm": 40.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2575,
+    "diameter_mm": 6.541
+  },
+  {
+    "name": "25-35 WINCHESTER",
+    "specs": {
+      "coal_in": 2.550,
+      "coal_mm": 64.77
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2580,
+    "diameter_mm": 6.553
+  },
+  {
+    "name": "250 SAVAGE",
+    "specs": {
+      "coal_in": 2.515,
+      "coal_mm": 63.88
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2580,
+    "diameter_mm": 6.553
+  },
+  {
+    "name": "257 ROBERTS/257 ROBERTS +P",
+    "specs": {
+      "coal_in": 2.780,
+      "coal_mm": 70.612
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2580,
+    "diameter_mm": 6.553
+  },
+  {
+    "name": "257 Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.209,
+      "coal_mm": 81.51
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2573,
+    "diameter_mm": 6.535
+  },
+  {
+    "name": "26 NOSLER",
     "specs": {
       "coal_in": 3.34,
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
+    "diameter_in": 0.2645,
+    "diameter_mm": 6.718
+  },
+  {
+    "name": "260 REMINGTON",
+    "specs": {
+      "coal_in": 2.8,
+      "coal_mm": 71.12
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2645,
+    "diameter_mm": 6.718
+  },
+  {
+    "name": "264 WINCHESTER MAGNUM",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.265,
+    "diameter_mm": 6.73
+  },
+  {
+    "name": "27 NOSLER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2780,
+    "diameter_mm": 7.061
+  },
+  {
+    "name": "270 Weatherby Magnum",
+    "specs": {
+      "coal_in": 3.295,
+      "coal_mm": 83.69
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2773,
+    "diameter_mm": 7.043
+  },
+  {
+    "name": "270 WINCHESTER",
+    "specs": {
+      "coal_in": 3.34,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2780,
+    "diameter_mm": 7.061
+  },
+  {
+    "name": "270 WINCHESTER SHORT MAGNUM",
+    "specs": {
+      "coal_in": 2.860,
+      "coal_mm": 72.64
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2780,
+    "diameter_mm": 7.061
+  },
+  {
+    "name": "28 NOSLER",
+    "specs": {
+      "coal_in": 3.340,
+      "coal_mm": 84.84
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "280 Ackley Improved",
+    "specs": {
+      "coal_in": 3.330,
+      "coal_mm": 84.58
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
+  },
+  {
+    "name": "280 REMINGTON",
+    "specs": {
+      "coal_in": 3.330,
+      "coal_mm": 84.58
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.2845,
+    "diameter_mm": 7.226
   },
   {
     "name": "284 WINCHESTER",
     "specs": {
-      "coal_in": 3.34,
-      "coal_mm": 84.84
+      "coal_in": 2.800,
+      "coal_mm": 71.12
     },
     "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
+    "diameter_in": 0.2840,
+    "diameter_mm": 7.214
   },
   {
     "name": "30 Carbine",
     "specs": {
-      "coal_in": 1.7,
-      "coal_mm": 43.18
+      "coal_in": 1.680,
+      "coal_mm": 42.67
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "30 NOSLER",
@@ -36,8 +546,8 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "30 REMINGTON AR",
@@ -46,18 +556,18 @@
       "coal_mm": 57.4
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "30 Thompson Center",
     "specs": {
-      "coal_in": 2.225,
-      "coal_mm": 56.51
+      "coal_in": 2.260,
+      "coal_mm": 67.56
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "30-06 SPRINGFIELD",
@@ -66,28 +576,28 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "30-30 WINCHESTER",
     "specs": {
-      "coal_in": 2.557,
-      "coal_mm": 64.95
+      "coal_in": 2.550,
+      "coal_mm": 64.77
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "30-40 KRAG",
     "specs": {
-      "coal_in": 2.93,
-      "coal_mm": 74.42
+      "coal_in": 3.089,
+      "coal_mm": 78.46
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "300 AAC Blackout",
@@ -96,8 +606,8 @@
       "coal_mm": 57.4
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "300 HOLLAND & HOLLAND MAGNUM",
@@ -106,53 +616,58 @@
       "coal_mm": 91.44
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "300 Remington Short Action Ultra Magnum",
     "specs": {
-      "coal_in": 2.86,
-      "coal_mm": 72.64
+      "coal_in": 2.825,
+      "coal_mm": 71.76
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "300 REMINGTON ULTRA MAGNUM",
-    "specs": {},
-    "standard": "SAAMI"
+    "specs": {
+      "coal_in": 3.600,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "300 RUGER COMPACT MAGNUM",
     "specs": {
-      "coal_in": 2.825,
-      "coal_mm": 71.75
+      "coal_in": 2.840,
+      "coal_mm": 72.14
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "300 SAVAGE",
     "specs": {
-      "coal_in": 2.63,
-      "coal_mm": 66.8
+      "coal_in": 2.600,
+      "coal_mm": 66.04
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "300 WEATHERBY MAGNUM",
     "specs": {
-      "coal_in": 3.6,
-      "coal_mm": 91.44
+      "coal_in": 3.560,
+      "coal_mm": 90.424
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.3083,
+    "diameter_mm": 7.83
   },
   {
     "name": "300 WINCHESTER MAGNUM",
@@ -161,14 +676,14 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "300 WINCHESTER SHORT MAGNUM",
     "specs": {
       "coal_in": 2.86,
-      "coal_mm": 72.646
+      "coal_mm": 72.64
     },
     "standard": "SAAMI",
     "diameter_in": 0.308,
@@ -177,62 +692,62 @@
   {
     "name": "303 British",
     "specs": {
-      "coal_in": 2.89,
-      "coal_mm": 73.4
+      "coal_in": 3.075,
+      "coal_mm": 78.11
     },
     "standard": "SAAMI",
-    "diameter_in": 0.311,
-    "diameter_mm": 7.9
+    "diameter_in": 0.3125,
+    "diameter_mm": 7.938
   },
   {
     "name": "307 WINCHESTER",
     "specs": {
-      "coal_in": 2.87,
+      "coal_in": 2.560,
       "coal_mm": 72.9
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.3435,
+    "diameter_mm": 7.849
   },
   {
     "name": "308 MARLIN EXPRESS",
     "specs": {
-      "coal_in": 2.55,
-      "coal_mm": 64.77
+      "coal_in": 2.600,
+      "coal_mm": 64.04
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.3085,
+    "diameter_mm": 7.836
   },
   {
     "name": "308 WINCHESTER",
     "specs": {
-      "coal_in": 2.81,
-      "coal_mm": 71.37
+      "coal_in": 2.810,
+      "coal_mm": 71.374
     },
     "standard": "SAAMI",
-    "diameter_in": 0.308,
-    "diameter_mm": 7.82
+    "diameter_in": 0.309,
+    "diameter_mm": 7.849
   },
   {
     "name": "32 WINCHESTER SPECIAL",
     "specs": {
-      "coal_in": 2.56,
-      "coal_mm": 65.02
+      "coal_in": 2.565,
+      "coal_mm": 65.15
     },
     "standard": "SAAMI",
-    "diameter_in": 0.321,
-    "diameter_mm": 8.15
+    "diameter_in": 0.322,
+    "diameter_mm": 8.179
   },
   {
     "name": "32-20 WINCHESTER",
     "specs": {
-      "coal_in": 1.428,
-      "coal_mm": 36.32
+      "coal_in": 1.592,
+      "coal_mm": 40.44
     },
     "standard": "SAAMI",
-    "diameter_in": 0.317,
-    "diameter_mm": 8.05
+    "diameter_in": 0.3125,
+    "diameter_mm": 7.938
   },
   {
     "name": "325 WINCHESTER SHORT MAGNUM",
@@ -241,8 +756,8 @@
       "coal_mm": 72.64
     },
     "standard": "SAAMI",
-    "diameter_in": 0.323,
-    "diameter_mm": 8.2
+    "diameter_in": 0.3235,
+    "diameter_mm": 8.217
   },
   {
     "name": "33 NOSLER",
@@ -251,18 +766,18 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.338,
-    "diameter_mm": 8.59
+    "diameter_in": 0.3390,
+    "diameter_mm": 8.611
   },
   {
     "name": "338 FEDERAL",
     "specs": {
-      "coal_in": 2.0,
-      "coal_mm": 50.8
+      "coal_in": 2.820,
+      "coal_mm": 71.63
     },
     "standard": "SAAMI",
-    "diameter_in": 0.338,
-    "diameter_mm": 8.58
+    "diameter_in": 0.339,
+    "diameter_mm": 8.611
   },
   {
     "name": "338 Lapua Magnum",
@@ -271,33 +786,38 @@
       "coal_mm": 93.5
     },
     "standard": "SAAMI",
-    "diameter_in": 0.338,
-    "diameter_mm": 8.58
+    "diameter_in": 0.339,
+    "diameter_mm": 8.61
   },
   {
     "name": "338 Marlin Express",
     "specs": {
-      "coal_in": 3.25,
-      "coal_mm": 82.55
+      "coal_in": 3.600,
+      "coal_mm": 66.04
     },
     "standard": "SAAMI",
-    "diameter_in": 0.338,
-    "diameter_mm": 8.59
+    "diameter_in": 0.3385,
+    "diameter_mm": 8.598
   },
   {
     "name": "338 REMINGTON ULTRA MAGNUM",
-    "specs": {},
-    "standard": "SAAMI"
+    "specs": {
+      "coal_in": 3.600,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.3383,
+    "diameter_mm": 8.593
   },
   {
     "name": "338 RUGER COMPACT MAGNUM",
     "specs": {
-      "coal_in": 2.8,
-      "coal_mm": 71.12
+      "coal_in": 2.840,
+      "coal_mm": 72.14
     },
     "standard": "SAAMI",
     "diameter_in": 0.338,
-    "diameter_mm": 8.59
+    "diameter_mm": 8.61
   },
   {
     "name": "338 WINCHESTER MAGNUM",
@@ -306,28 +826,28 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.338,
-    "diameter_mm": 8.58
+    "diameter_in": 0.339,
+    "diameter_mm": 8.611
   },
   {
     "name": "340 Weatherby Magnum",
     "specs": {
-      "coal_in": 3.6,
-      "coal_mm": 91.44
+      "coal_in": 3.7,
+      "coal_mm": 93.98
     },
     "standard": "SAAMI",
-    "diameter_in": 0.338,
-    "diameter_mm": 8.59
+    "diameter_in": 0.3383,
+    "diameter_mm": 8.593
   },
   {
     "name": "348 WINCHESTER",
     "specs": {
-      "coal_in": 2.8,
-      "coal_mm": 71.12
+      "coal_in": 2.795,
+      "coal_mm": 70.99
     },
     "standard": "SAAMI",
-    "diameter_in": 0.348,
-    "diameter_mm": 8.84
+    "diameter_in": 0.3495,
+    "diameter_mm": 8.877
   },
   {
     "name": "35 NOSLER",
@@ -342,12 +862,12 @@
   {
     "name": "35 REMINGTON",
     "specs": {
-      "coal_in": 2.27,
-      "coal_mm": 57.66
+      "coal_in": 2.525,
+      "coal_mm": 64.14
     },
     "standard": "SAAMI",
-    "diameter_in": 0.358,
-    "diameter_mm": 9.09
+    "diameter_in": 0.359,
+    "diameter_mm": 9.119
   },
   {
     "name": "35 Whelen",
@@ -356,33 +876,38 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.358,
-    "diameter_mm": 9.09
+    "diameter_in": 0.359,
+    "diameter_mm": 9.119
   },
   {
     "name": "350 Remington Magnum",
     "specs": {
-      "coal_in": 2.825,
-      "coal_mm": 71.76
+      "coal_in": 2.800,
+      "coal_mm": 71.12
     },
     "standard": "SAAMI",
-    "diameter_in": 0.348,
-    "diameter_mm": 8.84
+    "diameter_in": 0.359,
+    "diameter_mm": 9.119
   },
   {
     "name": "356 WINCHESTER",
-    "specs": {},
-    "standard": "SAAMI"
+    "specs": {
+      "coal_in": 2.560,
+      "coal_mm": 65.02
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.3585,
+    "diameter_mm": 9.106
   },
   {
     "name": "358 WINCHESTER",
     "specs": {
-      "coal_in": 2.771,
-      "coal_mm": 70.41
+      "coal_in": 2.780,
+      "coal_mm": 70.61
     },
     "standard": "SAAMI",
-    "diameter_in": 0.358,
-    "diameter_mm": 9.09
+    "diameter_in": 0.3585,
+    "diameter_mm": 9.106
   },
   {
     "name": "36 NOSLER",
@@ -397,8 +922,8 @@
   {
     "name": "370 Sako Magnum",
     "specs": {
-      "coal_in": 2.244,
-      "coal_mm": 57.01
+      "coal_in": 3.346,
+      "coal_mm": 85.0
     },
     "standard": "SAAMI",
     "diameter_in": 0.366,
@@ -406,8 +931,13 @@
   },
   {
     "name": "375 HOLLAND & HOLLAND MAGNUM",
-    "specs": {},
-    "standard": "SAAMI"
+    "specs": {
+      "coal_in": 3.60,
+      "coal_mm": 91.44
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.376,
+    "diameter_mm": 9.55
   },
   {
     "name": "375 REMINGTON ULTRA MAGNUM",
@@ -416,8 +946,8 @@
       "coal_mm": 91.44
     },
     "standard": "SAAMI",
-    "diameter_in": 0.375,
-    "diameter_mm": 9.525
+    "diameter_in": 0.376,
+    "diameter_mm": 9.55
   },
   {
     "name": "375 RUGER",
@@ -426,24 +956,24 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.375,
-    "diameter_mm": 9.53
+    "diameter_in": 0.376,
+    "diameter_mm": 9.55
   },
   {
     "name": "375 WINCHESTER",
     "specs": {
-      "coal_in": 3.6,
-      "coal_mm": 91.44
+      "coal_in": 2.56,
+      "coal_mm": 65.02
     },
     "standard": "SAAMI",
-    "diameter_in": 0.375,
-    "diameter_mm": 9.53
+    "diameter_in": 0.376,
+    "diameter_mm": 9.55
   },
   {
     "name": "376 STEYR",
     "specs": {
-      "coal_in": 3.25,
-      "coal_mm": 82.55
+      "coal_in": 3.11,
+      "coal_mm": 79.00
     },
     "standard": "SAAMI",
     "diameter_in": 0.376,
@@ -452,47 +982,52 @@
   {
     "name": "38-40 WINCHESTER",
     "specs": {
-      "coal_in": 1.594,
-      "coal_mm": 40.5
+      "coal_in": 1.592,
+      "coal_mm": 40.44
     },
     "standard": "SAAMI",
-    "diameter_in": 0.401,
-    "diameter_mm": 10.19
+    "diameter_in": 0.4005,
+    "diameter_mm": 10.173
   },
   {
     "name": "38-55 WINCHESTER",
     "specs": {
-      "coal_in": 2.08,
-      "coal_mm": 52.83
+      "coal_in": 2.510,
+      "coal_mm": 63.75
     },
     "standard": "SAAMI",
-    "diameter_in": 0.376,
-    "diameter_mm": 9.55
+    "diameter_in": 0.377,
+    "diameter_mm": 9.576
   },
   {
     "name": "405 WINCHESTER",
     "specs": {
-      "coal_in": 3.34,
-      "coal_mm": 84.84
+      "coal_in": 3.115,
+      "coal_mm": 79.12
     },
     "standard": "SAAMI",
-    "diameter_in": 0.411,
-    "diameter_mm": 10.44
+    "diameter_in": 0.4115,
+    "diameter_mm": 10.452
   },
   {
     "name": "416 REMINGTON MAGNUM",
-    "specs": {},
-    "standard": "SAAMI"
-  },
-  {
-    "name": "416 RIGBY",
     "specs": {
-      "coal_in": 3.6,
+      "coal_in": 3.600,
       "coal_mm": 91.44
     },
     "standard": "SAAMI",
     "diameter_in": 0.416,
-    "diameter_mm": 10.57
+    "diameter_mm": 10.566
+  },
+  {
+    "name": "416 RIGBY",
+    "specs": {
+      "coal_in": 3.750,
+      "coal_mm": 95.250
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.4165,
+    "diameter_mm": 10.579
   },
   {
     "name": "416 RUGER",
@@ -501,14 +1036,14 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.416,
-    "diameter_mm": 10.57
+    "diameter_in": 0.4165,
+    "diameter_mm": 10.579
   },
   {
     "name": "416 Weatherby Magnum",
     "specs": {
-      "coal_in": 3.6,
-      "coal_mm": 91.44
+      "coal_in": 3.750,
+      "coal_mm": 95.25
     },
     "standard": "SAAMI",
     "diameter_in": 0.416,
@@ -521,35 +1056,38 @@
       "coal_mm": 40.89
     },
     "standard": "SAAMI",
-    "diameter_in": 0.429,
-    "diameter_mm": 10.9
+    "diameter_in": 0.432,
+    "diameter_mm": 10.973
   },
   {
     "name": "44-40 WINCHESTER",
-    "specs": {},
+    "specs": {
+      "coal_in": 1.592,
+      "coal_mm": 40.44
+    },
     "standard": "SAAMI",
     "diameter_in": 0.427,
-    "diameter_mm": 10.84
+    "diameter_mm": 10.846
   },
   {
     "name": "444 MARLIN",
     "specs": {
-      "coal_in": 2.555,
-      "coal_mm": 64.77
+      "coal_in": 2.570,
+      "coal_mm": 65.28
     },
     "standard": "SAAMI",
-    "diameter_in": 0.429,
-    "diameter_mm": 10.9
+    "diameter_in": 0.4305,
+    "diameter_mm": 10.935
   },
   {
     "name": "45-70 GOVERNMENT",
     "specs": {
-      "coal_in": 2.54,
-      "coal_mm": 64.52
+      "coal_in": 2.550,
+      "coal_mm": 64.77
     },
     "standard": "SAAMI",
     "diameter_in": 0.458,
-    "diameter_mm": 11.63
+    "diameter_mm": 11.633
   },
   {
     "name": "450 BUSHMASTER",
@@ -558,25 +1096,28 @@
       "coal_mm": 57.4
     },
     "standard": "SAAMI",
-    "diameter_in": 0.452,
-    "diameter_mm": 11.48
+    "diameter_in": 0.4525,
+    "diameter_mm": 11.494
   },
   {
     "name": "450 MARLIN",
     "specs": {
-      "coal_in": 2.555,
-      "coal_mm": 64.77
+      "coal_in": 2.550,
+      "coal_mm": 64.76
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.4583,
+    "diameter_mm": 11.641
+  },
+  {
+    "name": "457 WILD WEST GUNS",
+    "specs": {
+      "coal_in": 2.565,
+      "coal_mm": 67.69
     },
     "standard": "SAAMI",
     "diameter_in": 0.458,
     "diameter_mm": 11.63
-  },
-  {
-    "name": "457 WILD WEST GUNS",
-    "specs": {},
-    "standard": "SAAMI",
-    "diameter_in": 0.457,
-    "diameter_mm": 11.6
   },
   {
     "name": "458 Lott",
@@ -585,8 +1126,8 @@
       "coal_mm": 91.44
     },
     "standard": "SAAMI",
-    "diameter_in": 0.458,
-    "diameter_mm": 11.63
+    "diameter_in": 0.459,
+    "diameter_mm": 11.66
   },
   {
     "name": "458 WINCHESTER MAGNUM",
@@ -595,515 +1136,37 @@
       "coal_mm": 84.84
     },
     "standard": "SAAMI",
-    "diameter_in": 0.458,
-    "diameter_mm": 11.63
+    "diameter_in": 0.459,
+    "diameter_mm": 11.659
   },
   {
     "name": "470 NITRO EXPRESS",
     "specs": {
-      "coal_in": 3.875,
-      "coal_mm": 98.43
+      "coal_in": 3.980,
+      "coal_mm": 101.092
     },
     "standard": "SAAMI",
-    "diameter_in": 0.475,
-    "diameter_mm": 12.07
+    "diameter_in": 0.4744,
+    "diameter_mm": 12.05
   },
   {
     "name": "475 TURNBULL",
-    "specs": {},
-    "standard": "SAAMI"
+    "specs": {
+      "coal_in": 2.780,
+      "coal_mm": 70.61
+    },
+    "standard": "SAAMI",
+    "diameter_in": 0.4755,
+    "diameter_mm": 12.078
   },
   {
     "name": "500 NITRO EXPRESS 3",
     "specs": {
-      "coal_in": 3.0,
-      "coal_mm": 76.2
+      "coal_in": 3.75,
+      "coal_mm": 95.25
     },
     "standard": "SAAMI",
-    "diameter_in": 0.51,
-    "diameter_mm": 12.95
-  },
-  {
-    "name": "6 X 45mm",
-    "specs": {},
-    "standard": "SAAMI",
-    "diameter_in": 0.236,
-    "diameter_mm": 6
-  },
-  {
-    "name": "6mm REMINGTON",
-    "specs": {
-      "coal_in": 2.8,
-      "coal_mm": 71.12
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.243,
-    "diameter_mm": 6.17
-  },
-  {
-    "name": "6.5 Creedmoor",
-    "specs": {
-      "coal_in": 2.825,
-      "coal_mm": 71.75
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.264,
-    "diameter_mm": 6.71
-  },
-  {
-    "name": "6.5 Grendel",
-    "specs": {
-      "coal_in": 2.26,
-      "coal_mm": 57.4
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.264,
-    "diameter_mm": 6.71
-  },
-  {
-    "name": "6.5 X 55 SWEDISH",
-    "specs": {
-      "coal_in": 3.15,
-      "coal_mm": 80.01
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.264,
-    "diameter_mm": 6.71
-  },
-  {
-    "name": "6.8mm REMINGTON SPC",
-    "specs": {},
-    "standard": "SAAMI",
-    "diameter_in": 0.277,
-    "diameter_mm": 7.04
-  },
-  {
-    "name": "7mm Mauser (7x57)",
-    "specs": {
-      "coal_in": 3.102,
-      "coal_mm": 78.747
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.214
-  },
-  {
-    "name": "7mm Remington Magnum",
-    "specs": {
-      "coal_in": 2.76,
-      "coal_mm": 70.104
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.2136
-  },
-  {
-    "name": "7mm Remington Short Action Ultra Magnum",
-    "specs": {},
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
-  },
-  {
-    "name": "7mm Remington Ultra Magnum",
-    "specs": {
-      "coal_in": 3.6,
-      "coal_mm": 91.44
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
-  },
-  {
-    "name": "7mm Shooting Times Westerner",
-    "specs": {
-      "coal_in": 3.315,
-      "coal_mm": 84.15
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
-  },
-  {
-    "name": "7mm Weatherby Magnum",
-    "specs": {
-      "coal_in": 3.6,
-      "coal_mm": 91.44
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
-  },
-  {
-    "name": "7mm Winchester Short Magnum",
-    "specs": {
-      "coal_in": 2.1,
-      "coal_mm": 53.34
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
-  },
-  {
-    "name": "7mm-08 REMINGTON",
-    "specs": {
-      "coal_in": 2.81,
-      "coal_mm": 71.37
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
-  },
-  {
-    "name": "7 x 64 BRENNEKE",
-    "specs": {
-      "coal_in": 3.228,
-      "coal_mm": 82.0
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
-  },
-  {
-    "name": "7-30 Waters",
-    "specs": {
-      "coal_in": 2.55,
-      "coal_mm": 64.77
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
-  },
-  {
-    "name": "7.62 x 39",
-    "specs": {
-      "coal_in": 2.204,
-      "coal_mm": 56.0
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.312,
-    "diameter_mm": 7.92
-  },
-  {
-    "name": "8mm Mauser (8x57)",
-    "specs": {
-      "coal_in": 3.075,
-      "coal_mm": 78.11
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.323,
-    "diameter_mm": 8.2
-  },
-  {
-    "name": "8mm REMINGTON MAGNUM",
-    "specs": {
-      "coal_in": 3.6,
-      "coal_mm": 91.44
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.323,
-    "diameter_mm": 8.2
-  },
-  {
-    "name": "9.3 X 62",
-    "specs": {
-      "coal_in": 3.15,
-      "coal_mm": 80.0
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.366,
-    "diameter_mm": 9.3
-  },
-  {
-    "name": "17 Hornet",
-    "specs": {
-      "coal_in": 1.35,
-      "coal_mm": 34.29
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.172,
-    "diameter_mm": 4.37
-  },
-  {
-    "name": "17 REMINGTON",
-    "specs": {
-      "coal_in": 1.625,
-      "coal_mm": 41.275
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.172,
-    "diameter_mm": 4.368
-  },
-  {
-    "name": "17 Remington Fireball",
-    "specs": {
-      "coal_in": 1.825,
-      "coal_mm": 46.355
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.172,
-    "diameter_mm": 4.368
-  },
-  {
-    "name": "204 RUGER",
-    "specs": {
-      "coal_in": 2.26,
-      "coal_mm": 57.4
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.204,
-    "diameter_mm": 5.18
-  },
-  {
-    "name": "218 BEE",
-    "specs": {
-      "coal_in": 1.6,
-      "coal_mm": 40.64
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.224,
-    "diameter_mm": 5.69
-  },
-  {
-    "name": "22 HORNET",
-    "specs": {
-      "coal_in": 1.713,
-      "coal_mm": 43.458
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.224,
-    "diameter_mm": 5.689
-  },
-  {
-    "name": "22-250 REMINGTON",
-    "specs": {
-      "coal_in": 2.35,
-      "coal_mm": 59.69
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.224,
-    "diameter_mm": 5.69
-  },
-  {
-    "name": "220 Swift",
-    "specs": {
-      "coal_in": 3.56,
-      "coal_mm": 90.42
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.224,
-    "diameter_mm": 5.69
-  },
-  {
-    "name": "221 REMINGTON FIREBALL",
-    "specs": {},
-    "standard": "SAAMI"
-  },
-  {
-    "name": "222 REMINGTON",
-    "specs": {},
-    "standard": "SAAMI"
-  },
-  {
-    "name": "222 REMINGTON MAGNUM",
-    "specs": {},
-    "standard": "SAAMI"
-  },
-  {
-    "name": "223 REMINGTON",
-    "specs": {
-      "coal_in": 2.26,
-      "coal_mm": 57.4
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.224,
-    "diameter_mm": 5.69
-  },
-  {
-    "name": "223 WINCHESTER SUPER SHORT MAGNUM",
-    "specs": {},
-    "standard": "SAAMI",
-    "diameter_in": 0.223,
-    "diameter_mm": 5.66
-  },
-  {
-    "name": "225 Winchester",
-    "specs": {
-      "coal_in": 2.81,
-      "coal_mm": 71.4
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.224,
-    "diameter_mm": 5.56
-  },
-  {
-    "name": "243 WINCHESTER",
-    "specs": {
-      "coal_in": 2.71,
-      "coal_mm": 68.83
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.243,
-    "diameter_mm": 6.17
-  },
-  {
-    "name": "243 WINCHESTER SUPER SHORT MAGNUM",
-    "specs": {
-      "coal_in": 2.235,
-      "coal_mm": 56.77
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.243,
-    "diameter_mm": 6.17
-  },
-  {
-    "name": "25 WINCHESTER SUPER SHORT MAGNUM",
-    "specs": {},
-    "standard": "SAAMI"
-  },
-  {
-    "name": "25-06 REMINGTON",
-    "specs": {},
-    "standard": "SAAMI"
-  },
-  {
-    "name": "25-20 WINCHESTER",
-    "specs": {
-      "coal_in": 1.35,
-      "coal_mm": 34.29
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.257,
-    "diameter_mm": 6.53
-  },
-  {
-    "name": "25-35 WINCHESTER",
-    "specs": {
-      "coal_in": 2.05,
-      "coal_mm": 52.07
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.257,
-    "diameter_mm": 6.53
-  },
-  {
-    "name": "250 SAVAGE",
-    "specs": {
-      "coal_in": 2.565,
-      "coal_mm": 65.15
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.257,
-    "diameter_mm": 6.53
-  },
-  {
-    "name": "257 ROBERTS/257 ROBERTS +P",
-    "specs": {
-      "coal_in": 2.131,
-      "coal_mm": 54.13
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.257,
-    "diameter_mm": 6.53
-  },
-  {
-    "name": "257 Weatherby Magnum",
-    "specs": {
-      "coal_in": 3.25,
-      "coal_mm": 82.55
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.257,
-    "diameter_mm": 6.528
-  },
-  {
-    "name": "26 NOSLER",
-    "specs": {
-      "coal_in": 3.34,
-      "coal_mm": 84.836
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.264,
-    "diameter_mm": 6.71
-  },
-  {
-    "name": "260 REMINGTON",
-    "specs": {
-      "coal_in": 2.8,
-      "coal_mm": 71.12
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.264,
-    "diameter_mm": 6.71
-  },
-  {
-    "name": "264 WINCHESTER MAGNUM",
-    "specs": {
-      "coal_in": 3.34,
-      "coal_mm": 84.84
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.264,
-    "diameter_mm": 6.71
-  },
-  {
-    "name": "27 NOSLER",
-    "specs": {
-      "coal_in": 3.34,
-      "coal_mm": 84.84
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.277,
-    "diameter_mm": 7.04
-  },
-  {
-    "name": "270 Weatherby Magnum",
-    "specs": {
-      "coal_in": 3.669,
-      "coal_mm": 93.22
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.277,
-    "diameter_mm": 7.04
-  },
-  {
-    "name": "270 WINCHESTER",
-    "specs": {
-      "coal_in": 3.34,
-      "coal_mm": 84.84
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.277,
-    "diameter_mm": 7.04
-  },
-  {
-    "name": "270 WINCHESTER SHORT MAGNUM",
-    "specs": {
-      "coal_in": 2.36,
-      "coal_mm": 59.94
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.277,
-    "diameter_mm": 7.04
-  },
-  {
-    "name": "28 NOSLER",
-    "specs": {
-      "coal_in": 3.34,
-      "coal_mm": 84.84
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.2845,
-    "diameter_mm": 7.226
-  },
-  {
-    "name": "280 Ackley Improved",
-    "specs": {
-      "coal_in": 3.34,
-      "coal_mm": 84.84
-    },
-    "standard": "SAAMI",
-    "diameter_in": 0.284,
-    "diameter_mm": 7.21
+    "diameter_in": 0.512,
+    "diameter_mm": 13.00
   }
 ]

--- a/scraper/saami/README.md
+++ b/scraper/saami/README.md
@@ -1,0 +1,23 @@
+# Scrape SAAMI specs
+
+## API key
+You need an openai api key. Then set it as an environment variable to be picked up. For example:
+`export OPENAI_API_KEY=key_here`
+
+## Dependencies
+To run this scraper first install the required libraries via:
+`pip install -r requirements`
+
+## Running
+`python3 scrape.py`
+
+The current version will do the following:
+* It'll download the main cartridge pdf from the SAAMI website
+* The file is split into one pdf file per cartridge
+* These files are sent individually to the openai api to be parsed
+* The returned json is not perfect, so we massage it a bit
+  
+This should give you a json file for each cartridge.
+These files can then be merged into one saami.json file.
+
+It is possible to resume the process if it fails in the middle. Any existing json files will simply be skipped.

--- a/scraper/saami/README.md
+++ b/scraper/saami/README.md
@@ -21,3 +21,7 @@ This should give you a json file for each cartridge.
 These files can then be merged into one saami.json file.
 
 It is possible to resume the process if it fails in the middle. Any existing json files will simply be skipped.
+
+# TODOs
+Use the new structured output feature.
+https://openai.com/index/introducing-structured-outputs-in-the-api/

--- a/scraper/saami/main.py
+++ b/scraper/saami/main.py
@@ -1,0 +1,43 @@
+from source import SaamiSource
+from openai_parser import OpenAIParser
+from splitter import split
+
+import os
+import tempfile
+import logging
+import json
+
+logging.basicConfig(encoding='utf-8', level=logging.INFO)
+
+src = SaamiSource()
+parser = OpenAIParser()
+
+with tempfile.NamedTemporaryFile() as download_file:
+    src.download(download_file)
+
+    # Cut it into one file per caliber to make it easier on the AI
+    split_pdf_files = split(
+        download_file.name,
+        src.page_start,
+        src.page_end
+    )
+
+    # Send off to openai for parsing
+    for pdf_file in split_pdf_files:
+        # Skip if already found, we are probably resuming a job.
+        json_file = pdf_file + ".json"
+        if os.path.isfile(json_file):
+            os.remove(pdf_file)
+            continue
+
+        json_response = parser.parse_with_retries(pdf_file, 2)
+        # TODO there is probably a better way to tell the AI what exact format we want this in.
+        # But I don't trust it so I'm just going to do some manual conversion here.
+        json_response = parser.cleanup_data(json_response)
+
+        with open(json_file, "wb") as stream:
+            stream.write(json.dumps(json_response).encode())
+            stream.write("\n".encode())
+
+        os.remove(pdf_file)
+

--- a/scraper/saami/openai_parser.py
+++ b/scraper/saami/openai_parser.py
@@ -1,0 +1,187 @@
+from openai import OpenAI
+
+import os
+import logging
+import json
+import re
+
+logger = logging.getLogger(__name__)
+
+class OpenAIParser: 
+    def __init__(self): 
+        self.client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+    def parse_with_retries(self, pdf_file, tries):
+        # Sometimes the AI is lazy and doesn't do a good job.
+        # So we have to beg it nicely to try again.
+        json_response = None
+        while json_response == None and tries > 0:
+            tries -= 1
+
+            json_response = self.parse(pdf_file)
+            if json_response != None:
+                # We got a response, let's see how good it is.
+                # Name always seems to be extracted, but not the numbers for some reason.
+                # If we are at the end of our tries we just settle for what we have.
+                if "diameter_in" in json_response or tries <= 0:
+                    return json_response
+                    break
+                else:
+                    # Let's wipe this and try again.
+                    json_response = None
+                    
+        return None
+
+
+
+    def parse(self, file_path):
+        client = self.client
+
+        logger.info("Parsing %s with OpenAI", file_path)
+
+        vector_store = client.beta.vector_stores.create(
+            name="SAAMI specs",
+        )
+
+        with open(file_path, 'rb') as f:
+            client.beta.vector_stores.file_batches.upload_and_poll(
+                vector_store_id=vector_store.id,
+                files=[f]
+            )
+
+        assistant = client.beta.assistants.create(
+            name="SAAMI pdf parser",
+            instructions=(
+                "You are a reader and interpeter of SAAMI catridge specification pdf files."
+                "Never add any other text to the response."
+            ),
+            tools=[{"type": "file_search"}],
+            tool_resources={
+            "file_search": {
+                "vector_store_ids": [vector_store.id]
+            }
+            },
+            model="gpt-3.5-turbo",
+        )
+
+        thread = client.beta.threads.create()
+
+        prompt = f"""
+        The attached PDF contains a SAAMI cartridge and chamber specification document.
+        Please provide the following information in JSON format:
+        1. The name of the cartridge. Use the JSON key "name".
+        3. The maximum overall length of the cartridge in inches. Use the JSON key "coal_max_in".
+        4. The maximum overall length of the cartridge in mm. Use the JSON key "coal_max_mm".
+        5. The caliber of the bullet in inches. Use the JSON key "diameter_in".
+        6. The caliber of the bullet in mm. Use the JSON key "diameter_mm".
+
+        Respond only with a JSON object.
+        """
+
+        message = client.beta.threads.messages.create(
+            thread_id=thread.id,
+            role="user",
+            content=prompt,
+        )
+
+        run = client.beta.threads.runs.create_and_poll(
+            thread_id=thread.id,
+            assistant_id=assistant.id,
+        )
+
+        result = ""
+
+        if run.status == "completed":
+            messages = client.beta.threads.messages.list(thread_id=thread.id)
+
+            for message in messages:
+                if message.role != "assistant":
+                    continue
+
+                assert message.content[0].type == "text"
+                result = message.content[0].text.value
+
+            client.beta.assistants.delete(assistant.id)
+
+        if result == "":
+            return None
+
+        return self.reformat(result)
+
+    # The json format we receive from open ai is kept as simple as possible.
+    # Reformat this into what the repo standard is.
+    def reformat(self, json_str):
+        # These seem to come through sometimes but not always
+        json_str = json_str.replace("```json", "")
+        json_str = json_str.replace("```", "")
+        # Sometimes a stray \" shows up
+        json_str = json_str.replace("\\\"", "")
+        
+        print(json_str)
+        parsed_json = json.loads(json_str)
+        
+        # Sanity checks
+        if "name" not in parsed_json:
+            return None
+        
+        result = {
+            "name": parsed_json["name"],
+            "specs": {},
+            "standard": "SAAMI",
+        }
+        
+        # Everything else we treat as optional
+        if "coal_max_in" in parsed_json and self.is_valid(parsed_json["coal_max_in"]):
+            result["specs"]["coal_in"] = parsed_json["coal_max_in"]
+
+        if "coal_max_mm" in parsed_json and self.is_valid(parsed_json["coal_max_mm"]):
+            result["specs"]["coal_mm"] = parsed_json["coal_max_mm"]
+                        
+        if "diameter_in" in parsed_json and self.is_valid(parsed_json["diameter_in"]):
+            result["diameter_in"] = parsed_json["diameter_in"]
+
+        if "diameter_mm" in parsed_json and self.is_valid(parsed_json["diameter_mm"]):
+            result["diameter_mm"] = parsed_json["diameter_mm"]
+        
+        return result
+    
+    def is_valid(self, str):
+        if not str:
+            return False
+        
+        if str == "N/A":
+            return False
+        
+        if str == "NA":
+            return False
+
+        if str == "--":
+            return False
+        
+        if str == "Not provided":
+            return False
+        
+        return True
+    
+    def cleanup_data(self, data):
+        if "coal_in" in data["specs"]:
+            data["specs"]["coal_in"] = self.cleanup_number(data["specs"]["coal_in"])
+            
+        if "coal_mm" in data["specs"]:
+            data["specs"]["coal_mm"] = self.cleanup_number(data["specs"]["coal_mm"])
+
+        if "diameter_in" in data:
+            data["diameter_in"] = self.cleanup_number(data["diameter_in"])
+
+        if "diameter_mm" in data:
+            data["diameter_mm"] = self.cleanup_number(data["diameter_mm"])
+            
+        return data
+    
+    def cleanup_number(self, field):
+        # Sometimes these strings contain stray "inches" or "mm". Strip that
+        if isinstance(field, str):
+            field = re.sub("[^0-9\.]", "", field)
+            return float(field)
+        
+        return field

--- a/scraper/saami/requirements.txt
+++ b/scraper/saami/requirements.txt
@@ -1,0 +1,3 @@
+openai
+pypdf
+requests

--- a/scraper/saami/source.py
+++ b/scraper/saami/source.py
@@ -1,0 +1,17 @@
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+class SaamiSource: 
+    # Currently only one pdf so hard coding everything here
+    def __init__(self): 
+        self.url = "https://saami.org/wp-content/uploads/2023/11/ANSI-SAAMI-Z299.4-CFR-Approved-2015-12-14-Posting-Copy.pdf"
+        self.page_start = 48
+        self.page_end = 166
+
+    def download(self, output_file):
+        logger.info("Downloading " + self.url)
+        response = requests.get(self.url)
+        output_file.write(response.content)
+        logger.info("Download done")

--- a/scraper/saami/splitter.py
+++ b/scraper/saami/splitter.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+import logging
+
+from pypdf import PdfWriter, PdfReader
+
+logger = logging.getLogger(__name__)
+
+def split(pdf_file, first_page, last_page):  
+    logger.info("Splitting " + pdf_file)
+
+    inputpdf = PdfReader(open(pdf_file, "rb"))
+
+    outputfiles = []
+
+    for page in range(first_page, last_page):
+        output = PdfWriter()
+        output.add_page(inputpdf.pages[page])
+
+        outputfile = "page%s.pdf" % page
+        with open(outputfile, "wb") as outputStream:
+            output.write(outputStream)
+
+        outputfiles.append(outputfile)
+    
+    logger.info("Splitting done: %d files", len(outputfiles))
+
+    return outputfiles


### PR DESCRIPTION
I made an attempt at parsing this report: `https://saami.org/wp-content/uploads/2023/11/ANSI-SAAMI-Z299.4-CFR-Approved-2015-12-14-Posting-Copy.pdf`

It contains center fire rifle cartridges. Since the pdfs have drawings in them and differ a bit I figured this was a good opportunity to learn some OpenAI.

The current version will do the following:
* It'll download the main cartridge pdf from the SAAMI website.
* The file is split into one pdf file per cartridge.
* These files are sent individually to the openai api to be parsed.
* The returned json is not perfect, so we massage it a bit.

See the final output in saami.json. It's not too bad considering the input data. I have not done an in depth review to verify against the source material however. I'm also only extracting the main data: name, caliber and coal. I figure that's a good start.
